### PR TITLE
feat: Implement comprehensive 6-theme system with documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,31 @@
 ## Project Overview
 **UniKorn Campus Forum** - A modern campus forum application built with Nuxt 3/Vue.js frontend and Flask backend.
 
+## 🎨 Theme System (Latest Update - January 2025)
+**CRITICAL**: This project now uses a comprehensive 6-theme system. **ALL new components must use CSS custom properties instead of hardcoded colors.**
+
+### Quick Theme Development Rules
+```scss
+/* ✅ ALWAYS DO - Use theme variables */
+.component {
+  background: var(--surface-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-primary);
+  box-shadow: var(--shadow-small);
+}
+
+/* ❌ NEVER DO - Hardcoded colors */
+.bad-component {
+  background: #ffffff;
+  color: #000000;
+  border: 1px solid #cccccc;
+}
+```
+
+**📖 Complete Documentation**: See `THEME_SYSTEM.md` for full guidelines, theme variables, and development patterns.
+
+**🧪 Testing**: Test all new components in all 6 themes (Light, Dark, Cafe, Pro-Tech, Ocean, Sunset) before committing.
+
 ### Tech Stack
 - **Frontend**: Nuxt 3, Vue.js 3, TypeScript, SCSS
 - **Backend**: Flask, PostgreSQL, SQLAlchemy ORM

--- a/THEME_SYSTEM.md
+++ b/THEME_SYSTEM.md
@@ -1,0 +1,443 @@
+# Theme System Documentation
+
+## Overview
+The UniKorn Campus Forum uses a comprehensive theme system with 6 predefined themes that provide consistent styling across the entire application. This system replaces the previous background customization with a more systematic approach.
+
+## Available Themes
+
+### 1. Light Theme (简洁白)
+- **ID**: `light`
+- **Description**: Clean and minimalist light theme for daily use
+- **Primary Colors**: White backgrounds, blue accents
+- **Best For**: Daytime usage, reading-heavy tasks
+
+### 2. Dark Theme (深邃黑)
+- **ID**: `dark`
+- **Description**: Professional dark theme to reduce eye strain
+- **Primary Colors**: Dark backgrounds, blue accents
+- **Best For**: Night usage, coding, extended reading
+
+### 3. Cafe Theme (温馨咖)
+- **ID**: `cafe`
+- **Description**: Warm brown tones creating a cozy atmosphere
+- **Primary Colors**: Brown/amber backgrounds, warm accents
+- **Best For**: Casual browsing, relaxed environment
+
+### 4. Pro-Tech Theme (科技蓝)
+- **ID**: `pro-tech`
+- **Description**: Modern tech-inspired theme with blue gradients
+- **Primary Colors**: Blue gradients, tech-style accents
+- **Best For**: Professional use, tech discussions
+
+### 5. Ocean Theme (海洋蓝)
+- **ID**: `ocean`
+- **Description**: Calming blue theme inspired by ocean depths
+- **Primary Colors**: Deep blue backgrounds, cyan accents
+- **Best For**: Focus work, calming environment
+
+### 6. Sunset Theme (温暖橙)
+- **ID**: `sunset`
+- **Description**: Energetic orange theme with warm vibes
+- **Primary Colors**: Orange/coral backgrounds, warm accents
+- **Best For**: Creative work, energetic atmosphere
+
+## Theme System Architecture
+
+### Core Files
+```
+/types/theme.ts              # TypeScript interfaces
+/utils/themes.ts             # Theme configurations
+/store/themeStore.ts         # Pinia state management
+/components/setting/ThemeSettings.vue  # Theme selection UI
+/plugins/theme.client.ts     # Theme initialization
+```
+
+### CSS Variable System
+Each theme generates CSS custom properties that components use for styling:
+
+```css
+/* Text Colors */
+--text-primary      /* Main text - adapts to background */
+--text-secondary    /* Secondary text - slightly muted */
+--text-muted        /* Muted text - for less important content */
+--text-inverse      /* ❌ AVOID - opposite of background (poor contrast) */
+
+/* Background Colors */
+--bg-primary        /* Main page background */
+--bg-secondary      /* Secondary backgrounds */
+--surface-primary   /* Card/component surfaces */
+--surface-secondary /* Elevated surfaces */
+--surface-elevated  /* Highest elevation surfaces */
+--surface-overlay   /* Overlay/modal backgrounds */
+
+/* Interactive Elements */
+--interactive-primary    /* Primary buttons, links */
+--interactive-secondary  /* Secondary interactive elements */
+--interactive-hover      /* Hover states */
+
+/* Borders & Shadows */
+--border-primary    /* Main borders */
+--border-secondary  /* Secondary borders */
+--border-focus      /* Focus states */
+--shadow-small      /* Subtle shadows */
+--shadow-medium     /* Standard shadows */
+--shadow-large      /* Prominent shadows */
+
+/* Semantic Colors */
+--semantic-success  /* Success states (green) */
+--semantic-warning  /* Warning states (yellow) */
+--semantic-error    /* Error states (red) */
+--semantic-info     /* Info states (blue) */
+```
+
+## Critical Development Rules
+
+### ✅ DO - Best Practices
+
+#### 1. Always Use Theme Variables
+```scss
+// ✅ CORRECT - Uses theme variables
+.my-component {
+  background: var(--surface-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-primary);
+  box-shadow: var(--shadow-small);
+}
+```
+
+#### 2. Use Correct Text Color Variables
+```scss
+// ✅ CORRECT - Adaptive text colors
+.title {
+  color: var(--text-primary);     // Main readable text
+}
+.subtitle {
+  color: var(--text-secondary);   // Slightly muted
+}
+.caption {
+  color: var(--text-muted);       // Very subtle text
+}
+```
+
+#### 3. Layer Backgrounds Properly
+```scss
+// ✅ CORRECT - Proper layering
+.page {
+  background: var(--bg-primary);           // Base layer
+}
+.card {
+  background: var(--surface-primary);      // Card layer
+}
+.modal {
+  background: var(--surface-elevated);     // Elevated layer
+}
+```
+
+### ❌ DON'T - Common Mistakes
+
+#### 1. Never Use Hardcoded Colors
+```scss
+// ❌ WRONG - Hardcoded colors break themes
+.bad-component {
+  background: #ffffff;
+  color: #000000;
+  border: 1px solid #cccccc;
+}
+```
+
+#### 2. Don't Use --text-inverse for Regular Text
+```scss
+// ❌ WRONG - Creates poor contrast
+.bad-text {
+  color: var(--text-inverse);  // White on white, black on black!
+}
+
+// ✅ CORRECT - Use primary for readable text
+.good-text {
+  color: var(--text-primary);  // Always readable
+}
+```
+
+#### 3. Don't Mix Theme and Hardcoded Styles
+```scss
+// ❌ WRONG - Inconsistent styling
+.mixed-component {
+  background: var(--surface-primary);  // Theme variable
+  color: #333333;                      // Hardcoded color
+}
+```
+
+## Component Development Guidelines
+
+### New Component Checklist
+When creating a new component, ensure:
+
+- [ ] All colors use CSS custom properties (--variable-name)
+- [ ] Text uses `--text-primary`, `--text-secondary`, or `--text-muted`
+- [ ] Backgrounds use appropriate surface variables
+- [ ] Interactive elements use `--interactive-*` variables
+- [ ] Borders use `--border-*` variables
+- [ ] Shadows use `--shadow-*` variables
+- [ ] Test component in all 6 themes
+- [ ] Verify text contrast in light and dark themes
+
+### Theme-Safe Color Patterns
+
+#### Cards and Containers
+```scss
+.card {
+  background: var(--surface-primary);
+  border: 1px solid var(--border-primary);
+  border-radius: 8px;
+  box-shadow: var(--shadow-small);
+  
+  .card-header {
+    background: var(--surface-secondary);
+    color: var(--text-primary);
+    border-bottom: 1px solid var(--border-secondary);
+  }
+  
+  .card-content {
+    color: var(--text-primary);
+    
+    .card-subtitle {
+      color: var(--text-secondary);
+    }
+  }
+}
+```
+
+#### Buttons and Interactive Elements
+```scss
+.btn {
+  // Primary button
+  &.btn-primary {
+    background: var(--interactive-primary);
+    color: var(--text-inverse);  // OK for buttons - ensures contrast
+    border: 1px solid var(--interactive-primary);
+    
+    &:hover {
+      background: var(--interactive-hover);
+    }
+  }
+  
+  // Secondary button
+  &.btn-secondary {
+    background: var(--surface-secondary);
+    color: var(--text-primary);
+    border: 1px solid var(--border-primary);
+    
+    &:hover {
+      background: var(--interactive-secondary);
+    }
+  }
+}
+```
+
+#### Form Elements
+```scss
+.form-input {
+  background: var(--surface-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-primary);
+  
+  &:focus {
+    border-color: var(--border-focus);
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+  }
+  
+  &::placeholder {
+    color: var(--text-muted);
+  }
+}
+```
+
+## Testing Your Components
+
+### Manual Testing Checklist
+Test your component in each theme:
+
+1. **Light Theme**: Verify dark text on light backgrounds
+2. **Dark Theme**: Verify light text on dark backgrounds  
+3. **Cafe Theme**: Check warm brown color adaptation
+4. **Pro-Tech Theme**: Ensure blue accent integration
+5. **Ocean Theme**: Verify blue theme compatibility
+6. **Sunset Theme**: Check orange theme harmony
+
+### Automated Testing
+```typescript
+// Example theme testing in component tests
+describe('MyComponent', () => {
+  const themes = ['light', 'dark', 'cafe', 'pro-tech', 'ocean', 'sunset'];
+  
+  themes.forEach(theme => {
+    it(`renders correctly in ${theme} theme`, () => {
+      // Set theme and test component rendering
+    });
+  });
+});
+```
+
+## Migration Guide
+
+### Converting Existing Components
+
+#### Step 1: Identify Hardcoded Colors
+```scss
+// Find patterns like:
+background: #ffffff;
+color: #000000;
+border: 1px solid #cccccc;
+```
+
+#### Step 2: Replace with Theme Variables
+```scss
+// Replace with:
+background: var(--surface-primary);
+color: var(--text-primary);
+border: 1px solid var(--border-primary);
+```
+
+#### Step 3: Test Across Themes
+- Switch between all 6 themes
+- Verify readability and contrast
+- Check for any broken layouts
+
+### Common Conversion Patterns
+
+| Old Hardcoded Style | New Theme Variable |
+|-------------------|-------------------|
+| `background: #ffffff` | `background: var(--surface-primary)` |
+| `color: #000000` | `color: var(--text-primary)` |
+| `color: #666666` | `color: var(--text-secondary)` |
+| `border: 1px solid #ddd` | `border: 1px solid var(--border-primary)` |
+| `box-shadow: 0 2px 4px rgba(0,0,0,0.1)` | `box-shadow: var(--shadow-small)` |
+
+## Advanced Features
+
+### Custom Theme Creation
+If you need to add a new theme:
+
+1. Add theme configuration to `/utils/themes.ts`
+2. Follow existing theme structure
+3. Test all components with new theme
+4. Update theme selection UI
+
+### Dynamic Theme Switching
+```typescript
+// In your component
+import { useThemeStore } from '~/store/themeStore'
+
+const themeStore = useThemeStore()
+
+// Switch theme
+themeStore.setTheme('dark')
+
+// Get current theme
+const currentTheme = themeStore.activeTheme
+```
+
+### Theme-Aware Components
+```vue
+<template>
+  <div class="component" :class="`theme-${currentTheme}`">
+    <!-- Component content -->
+  </div>
+</template>
+
+<script setup>
+const themeStore = useThemeStore()
+const currentTheme = computed(() => themeStore.currentTheme)
+</script>
+```
+
+## Performance Considerations
+
+### CSS Custom Properties
+- CSS variables are recalculated when theme changes
+- Avoid deep nesting of custom properties
+- Use cached computed styles where possible
+
+### Theme Switching
+- Theme changes trigger CSS recalculation
+- Minimize layout thrashing during transitions
+- Consider using `will-change` for animated elements
+
+## Troubleshooting
+
+### Common Issues
+
+#### Text Not Visible
+**Problem**: Text appears to be missing or unreadable
+**Solution**: Check if using `var(--text-inverse)` instead of `var(--text-primary)`
+
+#### Colors Don't Change with Theme
+**Problem**: Component colors remain static across themes
+**Solution**: Replace hardcoded colors with CSS custom properties
+
+#### Poor Contrast
+**Problem**: Text is hard to read in certain themes
+**Solution**: Use semantic color hierarchy (`--text-primary` → `--text-secondary` → `--text-muted`)
+
+#### Layout Breaks in Specific Theme
+**Problem**: Component layout fails in particular theme
+**Solution**: Test background/border combinations, ensure sufficient contrast
+
+### Debug Tools
+```javascript
+// Check current theme variables in DevTools console
+const root = document.documentElement;
+const styles = getComputedStyle(root);
+console.log('Text Primary:', styles.getPropertyValue('--text-primary'));
+console.log('Background:', styles.getPropertyValue('--bg-primary'));
+```
+
+## Future Enhancements
+
+### Planned Features
+- [ ] Auto dark mode based on system preferences
+- [ ] Custom theme creator for advanced users
+- [ ] Theme-based component variants
+- [ ] Accessibility improvements (high contrast mode)
+- [ ] Theme animation transitions
+
+### Extension Points
+- Add new semantic colors for specific use cases
+- Create theme-specific component variants
+- Implement theme inheritance for nested components
+
+---
+
+## Quick Reference
+
+### Most Used Variables
+```scss
+/* Essential colors for 90% of components */
+background: var(--surface-primary);
+color: var(--text-primary);
+border: 1px solid var(--border-primary);
+box-shadow: var(--shadow-small);
+
+/* Interactive elements */
+background: var(--interactive-primary);
+color: var(--text-inverse);  // Only for buttons/badges
+
+/* Secondary text */
+color: var(--text-secondary);
+
+/* Muted/subtle text */
+color: var(--text-muted);
+```
+
+### Remember
+- **Always** use theme variables, never hardcoded colors
+- **Test** in all 6 themes before committing
+- **Use** `--text-primary` for readable text, avoid `--text-inverse`
+- **Layer** backgrounds using surface variables
+- **Follow** semantic color meaning (success = green, error = red)
+
+---
+
+*Last Updated: December 2024*  
+*Version: 2.0*  
+*Contributors: Claude Code AI Assistant*

--- a/assets/css/variables.scss
+++ b/assets/css/variables.scss
@@ -1,7 +1,70 @@
 :root {
+  // Legacy compatibility
   --background-color: #97d4f3;
   --background-image: none;
   --background-opacity: 1;
+  
+  // Theme system variables (will be overridden by theme)
+  --bg-primary: #ffffff;
+  --bg-secondary: #f8fafc;
+  --bg-gradient: linear-gradient(135deg, #ffffff 0%, #f1f5f9 100%);
+  --bg-image: none;
+  
+  // Text colors
+  --text-primary: #1e293b;
+  --text-secondary: #475569;
+  --text-muted: #94a3b8;
+  --text-inverse: #ffffff;
+  
+  // Surface colors
+  --surface-primary: #ffffff;
+  --surface-secondary: #f8fafc;
+  --surface-elevated: #ffffff;
+  --surface-overlay: rgba(255, 255, 255, 0.95);
+  
+  // Interactive colors
+  --interactive-primary: #3b82f6;
+  --interactive-secondary: #e2e8f0;
+  --interactive-hover: #2563eb;
+  --interactive-active: #1d4ed8;
+  --interactive-disabled: #cbd5e1;
+  
+  // Semantic colors
+  --semantic-success: #10b981;
+  --semantic-warning: #f59e0b;
+  --semantic-error: #ef4444;
+  --semantic-info: #3b82f6;
+  
+  // Border colors
+  --border-primary: #e2e8f0;
+  --border-secondary: #f1f5f9;
+  --border-focus: #3b82f6;
+  
+  // Component backgrounds
+  --sidebar-bg: rgba(255, 255, 255, 0.95);
+  --sidebar-backdrop: blur(12px);
+  --sidebar-shadow: 0 4px 24px rgba(0, 0, 0, 0.06);
+  
+  --topbar-bg: rgba(255, 255, 255, 0.95);
+  --topbar-backdrop: blur(12px);
+  --topbar-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+  
+  --card-bg: #ffffff;
+  --card-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+  --card-border: 1px solid #e2e8f0;
+  
+  --modal-bg: #ffffff;
+  --modal-backdrop: rgba(0, 0, 0, 0.5);
+  --modal-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1);
+  
+  // Effects
+  --effect-blur: blur(12px);
+  --shadow-small: 0 1px 2px rgba(0, 0, 0, 0.05);
+  --shadow-medium: 0 4px 6px rgba(0, 0, 0, 0.07);
+  --shadow-large: 0 10px 15px rgba(0, 0, 0, 0.1);
+  --opacity-low: 0.6;
+  --opacity-medium: 0.8;
+  --opacity-high: 0.95;
   
   /* Mobile-first responsive breakpoints */
   --mobile-small: 480px;
@@ -37,11 +100,15 @@
 }
 
 body {
-  background-color: var(--background-color);
+  // Primary background (fallback)
+  background-color: var(--background-color, var(--bg-primary));
   margin: 0;
   min-height: 100vh;
   position: relative;
+  color: var(--text-primary);
+  transition: background-color var(--transition-normal), color var(--transition-normal);
   
+  // Main background layer
   &::before {
     content: "";
     position: fixed;
@@ -49,12 +116,90 @@ body {
     left: 0;
     width: 100%;
     height: 100%;
-    background-image: var(--background-image);
+    // Legacy support
+    background-image: var(--background-image, none);
     background-size: cover;
     background-position: center;
     background-repeat: no-repeat;
-    opacity: var(--background-opacity);
+    opacity: var(--background-opacity, 1);
+    z-index: -2;
+  }
+  
+  // New theme system background
+  &::after {
+    content: "";
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: var(--bg-gradient, var(--bg-primary));
     z-index: -1;
+  }
+  
+  // Theme-specific body classes
+  &.theme-light::after {
+    background: var(--bg-gradient);
+  }
+  
+  &.theme-dark::after {
+    background: var(--bg-gradient);
+  }
+  
+  &.theme-cafe::after {
+    background: var(--bg-gradient);
+    &::before {
+      content: "";
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: var(--bg-image, none);
+      opacity: 0.3;
+    }
+  }
+  
+  &.theme-pro-tech::after {
+    background: var(--bg-gradient);
+    &::before {
+      content: "";
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: var(--bg-image, none);
+      opacity: 0.4;
+    }
+  }
+  
+  &.theme-ocean::after {
+    background: var(--bg-gradient);
+    &::before {
+      content: "";
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: var(--bg-image, none);
+      opacity: 0.2;
+    }
+  }
+  
+  &.theme-sunset::after {
+    background: var(--bg-gradient);
+    &::before {
+      content: "";
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: var(--bg-image, none);
+      opacity: 0.25;
+    }
   }
 }
 

--- a/components/courses/CoursePosts.vue
+++ b/components/courses/CoursePosts.vue
@@ -285,13 +285,13 @@ onMounted(() => {
 
 <style lang="scss" scoped>
 .course-posts-section {
-  border-top: 1px solid #f0f0f0;
+  border-top: 1px solid var(--border-secondary);
 }
 
 .semester-section,
 .posts-section {
   padding: 2rem;
-  border-bottom: 1px solid #f0f0f0;
+  border-bottom: 1px solid var(--border-secondary);
 
   &:last-child {
     border-bottom: none;
@@ -301,18 +301,18 @@ onMounted(() => {
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    color: #2c3e50;
+    color: var(--text-primary);
     margin-bottom: 1.5rem;
     font-size: 1.25rem;
     flex-wrap: wrap;
 
     i {
-      color: #3498db;
+      color: var(--interactive-primary);
       min-width: 20px;
     }
 
     .posts-count {
-      color: #666;
+      color: var(--text-muted);
       font-size: 0.9rem;
       font-weight: normal;
     }
@@ -360,8 +360,8 @@ onMounted(() => {
 
 .semester-tab {
   padding: 0.5rem 1rem;
-  border: 2px solid #ddd;
-  background: white;
+  border: 2px solid var(--border-primary);
+  background: var(--surface-primary);
   border-radius: 20px;
   cursor: pointer;
   transition: all 0.3s ease;
@@ -375,13 +375,14 @@ onMounted(() => {
   white-space: nowrap;
 
   &:hover {
-    border-color: #3498db;
+    border-color: var(--interactive-primary);
+    background: var(--interactive-hover);
   }
 
   &.active {
-    background: #3498db;
-    color: white;
-    border-color: #3498db;
+    background: var(--interactive-primary);
+    color: var(--text-inverse);
+    border-color: var(--interactive-primary);
   }
   
   // Mobile optimization
@@ -420,8 +421,8 @@ onMounted(() => {
   }
 
   .create-post-btn {
-    background: #4caf50;
-    color: white;
+    background: var(--semantic-success);
+    color: var(--text-inverse);
     padding: 0.5rem 1rem;
     border-radius: 6px;
     text-decoration: none;
@@ -436,7 +437,7 @@ onMounted(() => {
     font-weight: 500;
 
     &:hover {
-      background: #45a049;
+      background: var(--interactive-hover);
     }
     
     // Mobile optimization
@@ -455,13 +456,13 @@ onMounted(() => {
 .posts-loading {
   text-align: center;
   padding: 2rem;
-  color: #666;
+  color: var(--text-muted);
 
   .loading-spinner.small {
     width: 30px;
     height: 30px;
-    border: 4px solid #f3f3f3;
-    border-top: 4px solid #3498db;
+    border: 4px solid var(--border-secondary);
+    border-top: 4px solid var(--interactive-primary);
     border-radius: 50%;
     animation: spin 1s linear infinite;
     margin: 0 auto 1rem;
@@ -494,7 +495,7 @@ onMounted(() => {
 .no-posts {
   text-align: center;
   padding: 3rem 2rem;
-  color: #666;
+  color: var(--text-muted);
 
   i {
     font-size: 3rem;
@@ -504,7 +505,7 @@ onMounted(() => {
   
   h4 {
     margin-bottom: 0.5rem;
-    color: #555;
+    color: var(--text-secondary);
   }
   
   p {
@@ -513,8 +514,8 @@ onMounted(() => {
   }
 
   .create-first-post-btn {
-    background: #3498db;
-    color: white;
+    background: var(--interactive-primary);
+    color: var(--text-inverse);
     padding: 0.75rem 1.5rem;
     border-radius: 6px;
     text-decoration: none;
@@ -529,7 +530,7 @@ onMounted(() => {
     justify-content: center;
 
     &:hover {
-      background: #2980b9;
+      background: var(--interactive-hover);
     }
   }
   
@@ -580,17 +581,17 @@ onMounted(() => {
 }
 
 .post-card {
-  background: #f8f9fa;
+  background: var(--card-bg);
   border-radius: 8px;
   padding: 1.5rem;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
-  border: 1px solid #e9ecef;
+  border: var(--card-border, 1px solid var(--border-primary));
   cursor: pointer;
 
   &:hover {
     transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-    border-color: #ced4da;
+    box-shadow: var(--shadow-medium);
+    border-color: var(--border-focus);
   }
   
   // Mobile optimization
@@ -599,7 +600,7 @@ onMounted(() => {
     
     &:hover {
       transform: translateY(-1px);
-      box-shadow: 0 3px 8px rgba(0, 0, 0, 0.08);
+      box-shadow: var(--shadow-small);
     }
   }
   
@@ -610,7 +611,7 @@ onMounted(() => {
     // Remove hover transform on small screens, add touch feedback
     &:hover {
       transform: none;
-      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+      box-shadow: var(--shadow-small);
     }
     
     // Add active state for touch feedback
@@ -626,7 +627,7 @@ onMounted(() => {
 
   .post-title {
     a {
-      color: #2c3e50;
+      color: var(--text-primary);
       text-decoration: none;
       font-size: 1.1rem;
       font-weight: 600;
@@ -636,7 +637,7 @@ onMounted(() => {
       min-height: 24px;
 
       &:hover {
-        color: #3498db;
+        color: var(--interactive-primary);
       }
     }
   }
@@ -646,7 +647,7 @@ onMounted(() => {
     gap: 1rem;
     margin-top: 0.5rem;
     font-size: 0.875rem;
-    color: #666;
+    color: var(--text-muted);
     flex-wrap: wrap;
   }
   
@@ -678,7 +679,7 @@ onMounted(() => {
 }
 
 .post-content {
-  color: #555;
+  color: var(--text-secondary);
   line-height: 1.6;
   margin-bottom: 1rem;
 }
@@ -690,8 +691,8 @@ onMounted(() => {
   flex-wrap: wrap;
 
   .post-tag {
-    background: #e9ecef;
-    color: #495057;
+    background: var(--surface-secondary);
+    color: var(--text-secondary);
     padding: 0.25rem 0.5rem;
     border-radius: 12px;
     font-size: 0.75rem;
@@ -702,7 +703,7 @@ onMounted(() => {
   display: flex;
   gap: 1rem;
   font-size: 0.875rem;
-  color: #666;
+  color: var(--text-muted);
   flex-wrap: wrap;
 
   span {
@@ -748,11 +749,12 @@ onMounted(() => {
 
   .page-btn {
     padding: 0.5rem 1rem;
-    border: 1px solid #ddd;
-    background: white;
+    border: 1px solid var(--border-primary);
+    background: var(--surface-primary);
     border-radius: 4px;
     cursor: pointer;
     transition: background 0.3s ease;
+    color: var(--text-primary);
     // Ensure touch-friendly sizing
     min-height: 44px;
     box-sizing: border-box;
@@ -762,8 +764,8 @@ onMounted(() => {
     font-size: 0.875rem;
 
     &:hover:not(:disabled) {
-      background: #f8f9fa;
-      border-color: #adb5bd;
+      background: var(--surface-elevated);
+      border-color: var(--border-focus);
     }
 
     &:disabled {
@@ -773,7 +775,7 @@ onMounted(() => {
   }
 
   .page-info {
-    color: #666;
+    color: var(--text-muted);
     font-size: 0.875rem;
     white-space: nowrap;
   }

--- a/components/forum/Post.vue
+++ b/components/forum/Post.vue
@@ -129,12 +129,13 @@ const goToUserProfile = (userId?: number) => {
 
 <style lang="scss" scoped>
 .post-card {
-  background-color: rgba(255, 255, 255, 0.7);
+  background-color: var(--card-bg);
   border-radius: 8px;
   padding: 1.5rem;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  box-shadow: var(--card-shadow, var(--shadow-small));
   transition: transform 0.2s, box-shadow 0.2s;
   cursor: pointer;
+  border: var(--card-border, 1px solid var(--border-primary));
   
   // Mobile optimizations
   @media (max-width: 480px) {
@@ -149,12 +150,12 @@ const goToUserProfile = (userId?: number) => {
 
   &:hover {
     transform: translateY(-3px);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    box-shadow: var(--shadow-medium);
     
     // Reduce hover effect on mobile for better touch experience
     @media (max-width: 768px) {
       transform: translateY(-1px);
-      box-shadow: 0 3px 8px rgba(0, 0, 0, 0.08);
+      box-shadow: var(--shadow-small);
     }
   }
   
@@ -184,7 +185,7 @@ const goToUserProfile = (userId?: number) => {
   }
 
   a {
-    color: #2c3e50;
+    color: var(--text-primary);
     text-decoration: none;
     word-wrap: break-word;
     display: block;
@@ -196,13 +197,13 @@ const goToUserProfile = (userId?: number) => {
     }
 
     &:hover {
-      color: #3498db;
+      color: var(--interactive-primary);
     }
     
     // Touch feedback
     &:active {
       @media (max-width: 768px) {
-        color: #2980b9;
+        color: var(--interactive-active);
       }
     }
   }
@@ -211,7 +212,7 @@ const goToUserProfile = (userId?: number) => {
 .post-meta {
   display: flex;
   gap: 1rem;
-  color: #666;
+  color: var(--text-muted);
   font-size: 0.9rem;
   margin-bottom: 0.75rem;
   align-items: center;
@@ -244,7 +245,7 @@ const goToUserProfile = (userId?: number) => {
 
     .author {
       font-weight: 500;
-      color: #333;
+      color: var(--text-secondary);
       
       @media (max-width: 480px) {
         font-size: 0.9rem;
@@ -277,8 +278,8 @@ const goToUserProfile = (userId?: number) => {
 
   .tag {
     font-size: 0.8rem;
-    background-color: #edf2f7;
-    color: #3182ce;
+    background-color: var(--surface-secondary);
+    color: var(--interactive-primary);
     padding: 0.2rem 0.6rem;
     border-radius: 4px;
     
@@ -292,7 +293,7 @@ const goToUserProfile = (userId?: number) => {
 
 .post-excerpt {
   margin-bottom: 1rem;
-  color: #333;
+  color: var(--text-secondary);
   display: -webkit-box;
   -webkit-line-clamp: 3;
   line-clamp: 3;
@@ -320,7 +321,7 @@ const goToUserProfile = (userId?: number) => {
 .post-stats {
   display: flex;
   gap: 1rem;
-  color: #666;
+  color: var(--text-muted);
   font-size: 0.9rem;
   margin-bottom: 1rem;
   flex-wrap: wrap;
@@ -346,7 +347,7 @@ const goToUserProfile = (userId?: number) => {
 }
 
 .read-more {
-  color: #3498db;
+  color: var(--interactive-primary);
   text-decoration: none;
   font-weight: 500;
   display: inline-block;
@@ -372,8 +373,8 @@ const goToUserProfile = (userId?: number) => {
   // Touch feedback
   &:active {
     @media (max-width: 768px) {
-      color: #2980b9;
-      background-color: rgba(52, 152, 219, 0.1);
+      color: var(--interactive-active);
+      background-color: var(--surface-secondary);
     }
   }
 }

--- a/components/home/HomeContainer.vue
+++ b/components/home/HomeContainer.vue
@@ -112,9 +112,9 @@ onUnmounted(() => {
   left: 0;
   right: 0;
   bottom: 0;
-  background-color: rgba(0, 0, 0, 0.5);
+  background-color: var(--modal-backdrop);
   z-index: 1005;
-  backdrop-filter: blur(2px);
+  backdrop-filter: var(--effect-blur);
 }
 
 .main-content {
@@ -123,6 +123,8 @@ onUnmounted(() => {
   padding: 1rem;
   min-height: calc(100vh - 70px);
   transition: margin-left 0.3s ease;
+  background: var(--bg-primary, transparent); /* Use theme background */
+  color: var(--text-primary);
   
   &.sidebar-collapsed {
     margin-left: 100px; /* 侧边栏折叠时的边距 */

--- a/components/home/Pinned.vue
+++ b/components/home/Pinned.vue
@@ -163,12 +163,13 @@ const handleSearchSelect = (type: string, item: any) => {
 
 <style lang="scss" scoped>
 .top-nav {
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
+  box-shadow: var(--topbar-shadow);
   display: flex;
   align-items: center;
-  background-color: var(--color-blue-7, #b9d2ea);
+  background: var(--topbar-bg);
+  backdrop-filter: var(--topbar-backdrop);
   padding: 0.5rem 1rem;
-  color: white;
+  color: var(--text-primary);
   height: 70px;
   width: 100%;
   position: fixed;
@@ -185,7 +186,7 @@ const handleSearchSelect = (type: string, item: any) => {
 .mobile-menu-btn {
   background: transparent;
   border: none;
-  color: white;
+  color: var(--text-primary);
   cursor: pointer;
   padding: 0.5rem;
   font-size: 1.125rem;
@@ -204,18 +205,18 @@ const handleSearchSelect = (type: string, item: any) => {
   }
 
   &:hover {
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: var(--interactive-secondary);
   }
 
   &:active {
-    background-color: rgba(255, 255, 255, 0.2);
+    background-color: var(--interactive-hover);
   }
 }
 
 .brand {
   font-size: 1.25rem;
   text-decoration: none;
-  color: white;
+  color: var(--text-primary);
   padding: 0.5rem 1rem;
   margin-right: 1rem;
   white-space: nowrap;
@@ -238,14 +239,14 @@ const handleSearchSelect = (type: string, item: any) => {
   }
 
   &:hover {
-    color: rgba(255, 255, 255, 0.75);
+    color: var(--text-secondary);
   }
 }
 
 .sidebar-toggle {
   background: transparent;
   border: none;
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--text-secondary);
   cursor: pointer;
   padding: 0.5rem;
   font-size: 1.125rem;
@@ -263,8 +264,8 @@ const handleSearchSelect = (type: string, item: any) => {
   }
 
   &:hover {
-    color: white;
-    background-color: rgba(255, 255, 255, 0.1);
+    color: var(--text-primary);
+    background-color: var(--interactive-secondary);
   }
 }
 
@@ -308,24 +309,24 @@ const handleSearchSelect = (type: string, item: any) => {
   }
 
   .dropdown-toggle {
-    color: rgba(255, 255, 255, 0.55);
+    color: var(--text-secondary);
     text-decoration: none;
     padding: 0.5rem;
     display: flex;
     align-items: center;
 
     &:hover {
-      color: rgba(255, 255, 255, 0.75);
+      color: var(--text-primary);
     }
 
     .user-icon-fallback {
       font-size: 1.2rem;
-      color: rgba(255, 255, 255, 0.75);
+      color: var(--text-primary);
     }
 
     .login-button {
-      background: rgba(255, 255, 255, 0.1);
-      border: 1px solid rgba(255, 255, 255, 0.3);
+      background: var(--interactive-secondary);
+      border: 1px solid var(--border-primary);
       border-radius: 20px;
       padding: 0.375rem 0.75rem;
       transition: all 0.2s ease;
@@ -339,13 +340,13 @@ const handleSearchSelect = (type: string, item: any) => {
       }
 
       &:hover {
-        background: rgba(255, 255, 255, 0.2);
-        border-color: rgba(255, 255, 255, 0.5);
+        background: var(--interactive-hover);
+        border-color: var(--border-focus);
         transform: translateY(-1px);
       }
 
       .login-text {
-        color: white;
+        color: var(--text-primary);
         font-size: 0.875rem;
         font-weight: 500;
       }
@@ -358,7 +359,7 @@ const handleSearchSelect = (type: string, item: any) => {
     height: 32px;
     border-radius: 50%;
     overflow: hidden;
-    border: 2px solid rgba(255, 255, 255, 0.2);
+    border: 2px solid var(--border-secondary);
 
     img {
       width: 100%;
@@ -372,13 +373,13 @@ const handleSearchSelect = (type: string, item: any) => {
     position: absolute;
     right: 0;
     top: calc(100% - 2px); /* Slight overlap to prevent gap */
-    background-color: white;
+    background-color: var(--surface-elevated);
     min-width: 10rem;
     padding: 0.5rem 0;
     margin: 0; /* Remove gap-causing margin */
-    border: 1px solid rgba(0, 0, 0, 0.15);
+    border: var(--card-border);
     border-radius: 0.25rem;
-    box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+    box-shadow: var(--card-shadow);
     z-index: 1000;
 
     /* Add padding-top to create invisible hover zone */
@@ -400,7 +401,7 @@ const handleSearchSelect = (type: string, item: any) => {
       padding: 0.5rem 1rem;
       margin-bottom: 0;
       font-size: 0.875rem;
-      color: #6c757d;
+      color: var(--text-muted);
       white-space: nowrap;
       font-weight: bold;
     }
@@ -414,12 +415,12 @@ const handleSearchSelect = (type: string, item: any) => {
       white-space: nowrap;
       background-color: transparent;
       border: 0;
-      color: #212529;
+      color: var(--text-primary);
       text-decoration: none;
 
       &:hover {
-        background-color: #f8f9fa;
-        color: #16181b;
+        background-color: var(--interactive-secondary);
+        color: var(--text-primary);
       }
     }
 
@@ -427,7 +428,7 @@ const handleSearchSelect = (type: string, item: any) => {
       height: 0;
       margin: 0.5rem 0;
       overflow: hidden;
-      border-top: 1px solid #e9ecef;
+      border-top: 1px solid var(--border-primary);
     }
   }
 }

--- a/components/home/Sidebar.vue
+++ b/components/home/Sidebar.vue
@@ -188,7 +188,7 @@ watch(isHovered, (newValue: boolean) => {
   height: 80px;
   border-radius: 50%;
   overflow: hidden;
-  border: 3px solid rgba(255, 255, 255, 0.2);
+  border: 3px solid var(--border-secondary);
   position: absolute;
   top: 50%;
   left: 50%;
@@ -207,8 +207,8 @@ watch(isHovered, (newValue: boolean) => {
     img {
       transform: scale(1.12) rotate(360deg);
     }
-    border-color: rgba(255, 255, 255, 0.8);
-    box-shadow: 0 0 20px rgba(255, 255, 255, 0.4);
+    border-color: var(--border-focus);
+    box-shadow: 0 0 20px var(--interactive-primary);
   }
 }
 
@@ -224,14 +224,15 @@ watch(isHovered, (newValue: boolean) => {
 }
 
 .sidebar {
-  box-shadow: 2px 0 10px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--sidebar-shadow);
   position: fixed;
   left: 0;
   top: 0;
   height: 100vh;
   width: 200px;
-  background-color: #677d94;
-  color: white;
+  background: var(--sidebar-bg);
+  backdrop-filter: var(--sidebar-backdrop);
+  color: var(--text-primary);
   transition: all 0.3s ease;
   z-index: 1010;
   padding: 0;
@@ -281,7 +282,7 @@ watch(isHovered, (newValue: boolean) => {
     }
 
     a {
-      color: rgba(255, 255, 255, 0.8);
+      color: var(--text-secondary);
       text-decoration: none;
       display: flex;
       align-items: center;
@@ -310,13 +311,13 @@ watch(isHovered, (newValue: boolean) => {
       }
 
       &:hover {
-        background-color: rgba(255, 255, 255, 0.1);
-        color: white;
+        background-color: var(--interactive-secondary);
+        color: var(--text-primary);
       }
 
       &.active {
-        background-color: rgba(255, 255, 255, 0.15) !important;
-        color: white !important;
+        background-color: var(--interactive-hover) !important;
+        color: var(--text-inverse) !important;
         font-weight: 600;
 
         &::before {
@@ -326,7 +327,7 @@ watch(isHovered, (newValue: boolean) => {
           top: 0;
           height: 100%;
           width: 4px;
-          background-color: white;
+          background-color: var(--interactive-primary);
           border-radius: 0 2px 2px 0;
         }
       }

--- a/components/setting/ThemeSettings.vue
+++ b/components/setting/ThemeSettings.vue
@@ -1,0 +1,650 @@
+<template>
+  <div class="theme-settings">
+    <!-- Theme Categories -->
+    <div class="settings-section">
+      <h3 class="section-title">
+        <i class="icon">🎨</i>
+        主题选择
+      </h3>
+      
+      <!-- Category Tabs -->
+      <div class="category-tabs">
+        <button
+          v-for="category in categories"
+          :key="category.id"
+          class="category-tab"
+          :class="{ active: activeCategory === category.id }"
+          @click="activeCategory = category.id"
+        >
+          <span class="category-icon">{{ category.icon }}</span>
+          <span class="category-name">{{ category.name }}</span>
+        </button>
+      </div>
+      
+      <!-- Theme Grid -->
+      <div class="theme-grid">
+        <div
+          v-for="theme in filteredThemes"
+          :key="theme.id"
+          class="theme-card"
+          :class="{ active: themeStore.currentTheme === theme.id }"
+          @click="selectTheme(theme.id)"
+        >
+          <div class="theme-preview" :style="getThemePreviewStyle(theme)">
+            <div class="preview-content">
+              <div class="preview-element sidebar"></div>
+              <div class="preview-element topbar"></div>
+              <div class="preview-element card"></div>
+            </div>
+          </div>
+          
+          <div class="theme-info">
+            <h4 class="theme-name">{{ theme.name }}</h4>
+            <p class="theme-description">{{ theme.description }}</p>
+          </div>
+          
+          <div v-if="themeStore.currentTheme === theme.id" class="active-indicator">
+            <span class="check-icon">✓</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Advanced Options -->
+    <div class="settings-section">
+      <h3 class="section-title">
+        <i class="icon">⚙️</i>
+        高级设置
+      </h3>
+      
+      <div class="advanced-options">
+        <!-- Auto Dark Mode -->
+        <div class="option-group">
+          <label class="option-label">
+            <input 
+              type="checkbox" 
+              v-model="autoDarkMode"
+              @change="toggleAutoDarkMode"
+              class="option-checkbox"
+            />
+            <span class="option-text">
+              <strong>自动深色模式</strong>
+              <span class="option-description">根据系统设置自动切换主题</span>
+            </span>
+          </label>
+        </div>
+        
+      </div>
+    </div>
+
+    <!-- Custom Theme (Future Feature) -->
+    <div class="settings-section">
+      <h3 class="section-title">
+        <i class="icon">🎪</i>
+        自定义主题
+      </h3>
+      
+      <div class="custom-theme-info">
+        <p class="info-text">
+          🚧 自定义主题功能正在开发中，敬请期待！
+        </p>
+        <p class="info-description">
+          未来您将能够：
+        </p>
+        <ul class="feature-list">
+          <li>调整颜色搭配</li>
+          <li>上传自定义背景</li>
+          <li>调节透明度和模糊效果</li>
+          <li>保存和分享主题</li>
+        </ul>
+      </div>
+    </div>
+
+    <!-- Quick Actions -->
+    <div class="settings-section">
+      <h3 class="section-title">
+        <i class="icon">⚡</i>
+        快速操作
+      </h3>
+      
+      <div class="quick-actions">
+        <button
+          class="action-btn reset-btn"
+          @click="resetTheme"
+        >
+          <i class="icon">🔄</i>
+          恢复默认主题
+        </button>
+        
+        <button
+          class="action-btn preview-btn"
+          @click="togglePreviewMode"
+        >
+          <i class="icon">👁️</i>
+          {{ previewMode ? '退出预览' : '预览模式' }}
+        </button>
+        
+        <button class="action-btn home-btn" @click="navigateToHome">
+          <i class="icon">🏠</i>
+          返回主页
+        </button>
+      </div>
+    </div>
+
+    <!-- Theme Application Status -->
+    <div v-if="isApplyingTheme" class="applying-overlay">
+      <div class="applying-content">
+        <div class="spinner">⟳</div>
+        <p>正在应用主题...</p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch, onMounted, onUnmounted } from 'vue';
+import { useThemeStore } from "~/store/themeStore";
+import { themes, getThemesByCategory } from '~/utils/themes';
+
+const themeStore = useThemeStore();
+
+// Reactive state
+const activeCategory = ref('light');
+const autoDarkMode = ref(false);
+const previewMode = ref(false);
+const isApplyingTheme = ref(false);
+
+// Categories
+const categories = [
+  { id: 'light', name: '浅色', icon: '☀️' },
+  { id: 'dark', name: '深色', icon: '🌙' },
+  { id: 'colored', name: '彩色', icon: '🌈' }
+];
+
+// Computed properties
+const filteredThemes = computed(() => {
+  return getThemesByCategory(activeCategory.value);
+});
+
+// Theme selection
+function selectTheme(themeId) {
+  if (isApplyingTheme.value) return;
+  
+  isApplyingTheme.value = true;
+  
+  // Small delay for visual feedback
+  setTimeout(() => {
+    themeStore.setTheme(themeId);
+    isApplyingTheme.value = false;
+  }, 300);
+}
+
+// Generate preview style for theme cards
+function getThemePreviewStyle(theme) {
+  return {
+    background: theme.background.gradient || theme.background.primary,
+    transition: 'all 0.2s ease'
+  };
+}
+
+// Auto dark mode
+function toggleAutoDarkMode() {
+  if (autoDarkMode.value) {
+    // Enable auto dark mode
+    enableAutoTheme();
+  } else {
+    // Disable auto dark mode
+    disableAutoTheme();
+  }
+}
+
+let mediaQuery = null;
+
+function enableAutoTheme() {
+  if (window.matchMedia) {
+    mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    
+    const handleChange = (e) => {
+      if (autoDarkMode.value) {
+        const preferredTheme = e.matches ? 'dark' : 'light';
+        selectTheme(preferredTheme);
+      }
+    };
+    
+    mediaQuery.addEventListener('change', handleChange);
+    
+    // Apply initial theme
+    const preferredTheme = mediaQuery.matches ? 'dark' : 'light';
+    selectTheme(preferredTheme);
+  }
+}
+
+function disableAutoTheme() {
+  if (mediaQuery) {
+    mediaQuery.removeEventListener('change', () => {});
+    mediaQuery = null;
+  }
+}
+
+// Quick actions
+function resetTheme() {
+  selectTheme('light');
+  autoDarkMode.value = false;
+  disableAutoTheme();
+}
+
+function togglePreviewMode() {
+  previewMode.value = !previewMode.value;
+  // Future: implement preview mode functionality
+}
+
+function navigateToHome() {
+  navigateTo("/");
+}
+
+// Lifecycle
+onMounted(() => {
+  // Initialize auto dark mode if user prefers dark theme
+  if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    if (themeStore.currentTheme === 'dark') {
+      autoDarkMode.value = true;
+      enableAutoTheme();
+    }
+  }
+});
+
+onUnmounted(() => {
+  disableAutoTheme();
+});
+
+// Watch for theme changes to update active category
+watch(() => themeStore.currentTheme, (newTheme) => {
+  const theme = themes.find(t => t.id === newTheme);
+  if (theme) {
+    activeCategory.value = theme.category;
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.theme-settings {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1rem;
+  
+  @media (min-width: 768px) {
+    padding: 1.5rem;
+  }
+}
+
+.settings-section {
+  background: var(--surface-primary);
+  border-radius: 16px;
+  padding: 1.5rem;
+  margin-bottom: 2rem;
+  box-shadow: var(--shadow-medium);
+  border: 1px solid var(--border-primary);
+  backdrop-filter: var(--effect-blur);
+  transition: all var(--transition-normal);
+  
+  @media (max-width: 767px) {
+    padding: 1rem;
+    border-radius: 12px;
+  }
+}
+
+.section-title {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 0 0 1.5rem 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  
+  .icon {
+    font-size: 1.4rem;
+  }
+  
+  @media (min-width: 768px) {
+    font-size: 1.4rem;
+    gap: 1rem;
+  }
+}
+
+// Category tabs
+.category-tabs {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 2rem;
+  padding: 4px;
+  background: var(--surface-secondary);
+  border-radius: 12px;
+  overflow-x: auto;
+}
+
+.category-tab {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  white-space: nowrap;
+  font-weight: 500;
+  
+  &:hover {
+    background: var(--surface-elevated);
+    color: var(--text-primary);
+  }
+  
+  &.active {
+    background: var(--interactive-primary);
+    color: var(--text-inverse);
+    box-shadow: var(--shadow-small);
+  }
+  
+  .category-icon {
+    font-size: 1.1rem;
+  }
+  
+  .category-name {
+    font-size: 0.9rem;
+  }
+}
+
+// Theme grid
+.theme-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+  
+  @media (max-width: 767px) {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+}
+
+.theme-card {
+  position: relative;
+  border: 2px solid var(--border-primary);
+  border-radius: 12px;
+  overflow: hidden;
+  cursor: pointer;
+  transition: all var(--transition-normal);
+  background: var(--surface-primary);
+  
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-large);
+    border-color: var(--interactive-primary);
+  }
+  
+  &.active {
+    border-color: var(--interactive-primary);
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
+  }
+}
+
+.theme-preview {
+  height: 120px;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+
+.preview-content {
+  display: grid;
+  grid-template-columns: 1fr 3fr;
+  grid-template-rows: auto 1fr;
+  gap: 4px;
+  width: 100%;
+  height: 80px;
+  opacity: 0.8;
+}
+
+.preview-element {
+  border-radius: 2px;
+  
+  &.sidebar {
+    grid-row: 1 / -1;
+    background: var(--sidebar-bg);
+    opacity: 0.9;
+  }
+  
+  &.topbar {
+    background: var(--topbar-bg);
+    opacity: 0.9;
+  }
+  
+  &.card {
+    background: var(--card-bg);
+    opacity: 0.9;
+  }
+}
+
+.theme-info {
+  padding: 1rem;
+  
+  .theme-name {
+    margin: 0 0 0.5rem 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+  
+  .theme-description {
+    margin: 0;
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+    line-height: 1.4;
+  }
+}
+
+.active-indicator {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  width: 24px;
+  height: 24px;
+  background: var(--interactive-primary);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  
+  .check-icon {
+    color: white;
+    font-size: 0.8rem;
+    font-weight: bold;
+  }
+}
+
+// Advanced options
+.advanced-options {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.option-group {
+  .option-label {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    cursor: pointer;
+    
+    .option-checkbox {
+      margin-top: 2px;
+      width: 18px;
+      height: 18px;
+      accent-color: var(--interactive-primary);
+    }
+    
+    .option-text {
+      flex: 1;
+      
+      strong {
+        display: block;
+        color: var(--text-primary);
+        margin-bottom: 0.25rem;
+      }
+      
+      .option-description {
+        font-size: 0.9rem;
+        color: var(--text-secondary);
+      }
+    }
+  }
+}
+
+.setting-label {
+  display: block;
+  margin-bottom: 0.75rem;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+// Custom theme info
+.custom-theme-info {
+  .info-text {
+    font-size: 1rem;
+    color: var(--text-secondary);
+    margin-bottom: 1rem;
+  }
+  
+  .info-description {
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+    margin-bottom: 0.5rem;
+  }
+  
+  .feature-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    
+    li {
+      padding: 0.25rem 0;
+      color: var(--text-secondary);
+      font-size: 0.9rem;
+      
+      &::before {
+        content: "✨ ";
+        margin-right: 0.5rem;
+      }
+    }
+  }
+}
+
+// Quick actions
+.quick-actions {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+  
+  @media (max-width: 767px) {
+    grid-template-columns: 1fr;
+  }
+}
+
+.action-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.875rem 1rem;
+  border: none;
+  border-radius: 8px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  font-size: 0.9rem;
+  
+  .icon {
+    font-size: 1rem;
+  }
+  
+  &:hover {
+    transform: translateY(-1px);
+    box-shadow: var(--shadow-medium);
+  }
+  
+  &:active {
+    transform: translateY(0);
+  }
+  
+  &.reset-btn {
+    background: var(--semantic-warning);
+    color: var(--text-inverse);
+    
+    &:hover {
+      background: #d97706;
+    }
+  }
+  
+  &.preview-btn {
+    background: var(--semantic-info);
+    color: var(--text-inverse);
+    
+    &:hover {
+      background: #2563eb;
+    }
+  }
+  
+  &.home-btn {
+    background: var(--interactive-primary);
+    color: var(--text-inverse);
+    
+    &:hover {
+      background: var(--interactive-hover);
+    }
+  }
+}
+
+// Applying overlay
+.applying-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: var(--modal-backdrop);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+  backdrop-filter: var(--effect-blur);
+}
+
+.applying-content {
+  background: var(--modal-bg);
+  padding: 2rem;
+  border-radius: 12px;
+  text-align: center;
+  box-shadow: var(--modal-shadow);
+  
+  .spinner {
+    font-size: 2rem;
+    animation: spin 1s linear infinite;
+    margin-bottom: 1rem;
+  }
+  
+  p {
+    margin: 0;
+    color: var(--text-primary);
+    font-weight: 500;
+  }
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+</style>

--- a/components/ui/ConfirmModal.vue
+++ b/components/ui/ConfirmModal.vue
@@ -81,7 +81,7 @@ const handleOverlayClick = () => {
   left: 0;
   width: 100%;
   height: 100%;
-  background-color: rgba(0, 0, 0, 0.5);
+  background-color: var(--modal-backdrop);
   display: flex;
   justify-content: center;
   align-items: center;
@@ -90,22 +90,23 @@ const handleOverlayClick = () => {
 }
 
 .modal-container {
-  background: white;
+  background: var(--modal-bg);
   border-radius: 12px;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--modal-shadow, var(--shadow-large));
   max-width: 400px;
   width: 90%;
   animation: slideIn 0.3s ease-out;
+  border: 1px solid var(--border-primary);
 }
 
 .modal-header {
   padding: 1.5rem 1.5rem 1rem;
   text-align: center;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--border-secondary);
 
   .warning-icon {
     font-size: 3rem;
-    color: #f39c12;
+    color: var(--semantic-warning);
     margin-bottom: 0.5rem;
     animation: pulse 2s infinite;
   }
@@ -113,14 +114,14 @@ const handleOverlayClick = () => {
   h3 {
     margin: 0;
     font-size: 1.25rem;
-    color: #2c3e50;
+    color: var(--text-primary);
   }
 }
 
 .modal-body {
   padding: 1rem 1.5rem;
   text-align: center;
-  color: #666;
+  color: var(--text-secondary);
   line-height: 1.5;
 }
 
@@ -141,24 +142,24 @@ const handleOverlayClick = () => {
   min-width: 80px;
 
   &.btn-cancel {
-    background-color: #f8f9fa;
-    color: #666;
-    border: 1px solid #dee2e6;
+    background-color: var(--surface-secondary);
+    color: var(--text-muted);
+    border: 1px solid var(--border-secondary);
 
     &:hover {
-      background-color: #e9ecef;
+      background-color: var(--surface-elevated);
       transform: translateY(-1px);
     }
   }
 
   &.btn-confirm {
-    background-color: #dc3545;
-    color: white;
+    background-color: var(--semantic-error);
+    color: var(--text-inverse);
 
     &:hover {
-      background-color: #c82333;
+      background-color: var(--interactive-active);
       transform: translateY(-1px);
-      box-shadow: 0 4px 12px rgba(220, 53, 69, 0.3);
+      box-shadow: var(--shadow-medium);
     }
   }
 }

--- a/components/ui/ErrorModal.vue
+++ b/components/ui/ErrorModal.vue
@@ -57,7 +57,7 @@ const handleClose = () => {
   left: 0;
   width: 100%;
   height: 100%;
-  background-color: rgba(0, 0, 0, 0.5);
+  background-color: var(--modal-backdrop);
   display: flex;
   justify-content: center;
   align-items: center;
@@ -66,14 +66,15 @@ const handleClose = () => {
 }
 
 .error-container {
-  background: white;
+  background: var(--modal-bg);
   border-radius: 16px;
   padding: 2rem;
   text-align: center;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--modal-shadow, var(--shadow-large));
   max-width: 350px;
   width: 90%;
   animation: shakeIn 0.6s ease-out;
+  border: 1px solid var(--border-primary);
 }
 
 .error-icon-wrapper {
@@ -88,8 +89,8 @@ const handleClose = () => {
   width: 80px;
   height: 80px;
   border-radius: 50%;
-  border: 4px solid rgba(220, 53, 69, 0.2);
-  border-left-color: #dc3545;
+  border: 4px solid var(--surface-secondary);
+  border-left-color: var(--semantic-error);
   animation: error_animation_collect 1s linear 1 both;
 }
 
@@ -97,19 +98,19 @@ const handleClose = () => {
 @keyframes error_animation_collect {
   0% {
     transform: rotate(270deg);
-    border-left-color: #dc3545;
+    border-left-color: var(--semantic-error);
   }
   25% {
-    border-left-color: #dc3545;
+    border-left-color: var(--semantic-error);
   }
   50% {
-    border-left-color: #dc3545;
+    border-left-color: var(--semantic-error);
   }
   75% {
-    border-left-color: #dc3545;
+    border-left-color: var(--semantic-error);
   }
   100% {
-    border-left-color: rgba(220, 53, 69, 0.2);
+    border-left-color: var(--surface-secondary);
     transform: rotate(0deg);
   }
 }
@@ -122,7 +123,7 @@ const handleClose = () => {
   left: 50%;
   width: 40px;
   height: 4px;
-  background: #dc3545;
+  background: var(--semantic-error);
   transform: translate(-50%, -50%) rotate(45deg);
   transform-origin: center;
   animation: error_line1 0.3s 1s linear 1 both;
@@ -137,7 +138,7 @@ const handleClose = () => {
   left: 50%;
   width: 40px;
   height: 4px;
-  background: #dc3545;
+  background: var(--semantic-error);
   transform: translate(-50%, -50%) rotate(-45deg);
   transform-origin: center;
   animation: error_line2 0.3s 1.3s linear 1 both;
@@ -170,13 +171,13 @@ const handleClose = () => {
 
 .error-title {
   font-size: 1.5rem;
-  color: #2c3e50;
+  color: var(--text-primary);
   margin: 0 0 0.5rem 0;
   font-weight: 600;
 }
 
 .error-message {
-  color: #666;
+  color: var(--text-secondary);
   margin: 0 0 1.5rem 0;
   line-height: 1.5;
 }
@@ -186,19 +187,19 @@ const handleClose = () => {
 }
 
 .btn-error {
-  background: linear-gradient(135deg, #dc3545, #c82333);
-  color: white;
+  background: linear-gradient(135deg, var(--semantic-error), var(--interactive-active));
+  color: var(--text-inverse);
   border: none;
   padding: 0.75rem 2rem;
   border-radius: 25px;
   font-size: 0.9rem;
   cursor: pointer;
   transition: all 0.3s ease;
-  box-shadow: 0 4px 15px rgba(220, 53, 69, 0.3);
+  box-shadow: var(--shadow-medium);
 
   &:hover {
     transform: translateY(-2px);
-    box-shadow: 0 6px 20px rgba(220, 53, 69, 0.4);
+    box-shadow: var(--shadow-large);
   }
 
   &:active {

--- a/components/ui/SearchDropdown.vue
+++ b/components/ui/SearchDropdown.vue
@@ -384,19 +384,20 @@ const stripHtml = (html: string) => {
   flex: 1;
   padding: 0.5rem 3rem 0.5rem 1rem;
   font-size: 0.875rem;
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--border-primary);
   border-radius: 0.5rem;
-  background: white;
+  background: var(--surface-primary);
+  color: var(--text-primary);
   transition: all 0.2s ease;
   
   &:focus {
     outline: none;
-    border-color: #3b82f6;
+    border-color: var(--border-focus);
     box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
   }
   
   &::placeholder {
-    color: #9ca3af;
+    color: var(--text-muted);
   }
 }
 
@@ -407,17 +408,17 @@ const stripHtml = (html: string) => {
   transform: translateY(-50%);
   background: none;
   border: none;
-  color: #6b7280;
+  color: var(--text-secondary);
   cursor: pointer;
   padding: 0.25rem;
   transition: color 0.2s ease;
   
   &:hover:not(:disabled) {
-    color: #3b82f6;
+    color: var(--interactive-primary);
   }
   
   &:disabled {
-    color: #d1d5db;
+    color: var(--text-muted);
     cursor: not-allowed;
   }
 }
@@ -429,13 +430,13 @@ const stripHtml = (html: string) => {
   transform: translateY(-50%);
   background: none;
   border: none;
-  color: #9ca3af;
+  color: var(--text-muted);
   cursor: pointer;
   padding: 0.25rem;
   transition: color 0.2s ease;
   
   &:hover {
-    color: #ef4444;
+    color: var(--semantic-error);
   }
 }
 
@@ -444,17 +445,17 @@ const stripHtml = (html: string) => {
   top: calc(100% + 0.25rem);
   left: 0;
   right: 0;
-  background: white;
-  border: 1px solid #e5e7eb;
+  background: var(--surface-elevated);
+  border: 1px solid var(--border-primary);
   border-radius: 0.5rem;
-  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-large);
   max-height: 32rem;
   overflow-y: auto;
   z-index: 50;
 }
 
 .dropdown-section {
-  border-bottom: 1px solid #f3f4f6;
+  border-bottom: 1px solid var(--border-secondary);
   
   &:last-child {
     border-bottom: none;
@@ -468,7 +469,7 @@ const stripHtml = (html: string) => {
   padding: 0.75rem 1rem 0.5rem;
   font-size: 0.75rem;
   font-weight: 600;
-  color: #6b7280;
+  color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   
@@ -479,7 +480,7 @@ const stripHtml = (html: string) => {
   .clear-history-btn {
     background: none;
     border: none;
-    color: #ef4444;
+    color: var(--semantic-error);
     cursor: pointer;
     font-size: 0.75rem;
     padding: 0.25rem;
@@ -508,7 +509,7 @@ const stripHtml = (html: string) => {
   transition: background-color 0.2s ease;
   
   &:hover {
-    background-color: #f9fafb;
+    background-color: var(--interactive-secondary);
   }
 }
 
@@ -522,7 +523,7 @@ const stripHtml = (html: string) => {
     .post-title {
       font-size: 0.875rem;
       font-weight: 600;
-      color: #1f2937;
+      color: var(--text-primary);
       margin: 0 0 0.25rem;
       line-height: 1.4;
       
@@ -536,7 +537,7 @@ const stripHtml = (html: string) => {
     
     .post-excerpt {
       font-size: 0.75rem;
-      color: #6b7280;
+      color: var(--text-secondary);
       margin: 0 0 0.5rem;
       line-height: 1.4;
       display: -webkit-box;
@@ -550,11 +551,11 @@ const stripHtml = (html: string) => {
       align-items: center;
       gap: 0.5rem;
       font-size: 0.75rem;
-      color: #9ca3af;
+      color: var(--text-muted);
       
       .author-name {
         font-weight: 500;
-        color: #6b7280;
+        color: var(--text-secondary);
       }
       
       .post-stats {
@@ -578,7 +579,7 @@ const stripHtml = (html: string) => {
     .user-name {
       font-size: 0.875rem;
       font-weight: 600;
-      color: #1f2937;
+      color: var(--text-primary);
       margin: 0 0 0.125rem;
       
       :deep(mark) {
@@ -591,14 +592,14 @@ const stripHtml = (html: string) => {
     
     .user-role {
       font-size: 0.75rem;
-      color: #6b7280;
+      color: var(--text-secondary);
     }
   }
 }
 
 .tag-item, .course-item {
   i {
-    color: #3b82f6;
+    color: var(--interactive-primary);
     margin-right: 0.75rem;
     font-size: 1rem;
   }
@@ -607,7 +608,7 @@ const stripHtml = (html: string) => {
     h4 {
       font-size: 0.875rem;
       font-weight: 600;
-      color: #1f2937;
+      color: var(--text-primary);
       margin: 0 0 0.125rem;
       
       :deep(mark) {
@@ -620,7 +621,7 @@ const stripHtml = (html: string) => {
     
     .tag-count, .course-name {
       font-size: 0.75rem;
-      color: #6b7280;
+      color: var(--text-secondary);
     }
   }
 }
@@ -630,7 +631,7 @@ const stripHtml = (html: string) => {
   align-items: center;
   justify-content: center;
   padding: 2rem 1rem;
-  color: #6b7280;
+  color: var(--text-secondary);
   font-size: 0.875rem;
   
   i {
@@ -639,7 +640,7 @@ const stripHtml = (html: string) => {
 }
 
 .error-item {
-  color: #ef4444;
+  color: var(--semantic-error);
 }
 
 .history-list {
@@ -659,40 +660,40 @@ const stripHtml = (html: string) => {
   transition: background-color 0.2s ease;
   
   &:hover {
-    background-color: #f9fafb;
+    background-color: var(--interactive-secondary);
   }
   
   i {
-    color: #9ca3af;
+    color: var(--text-muted);
     margin-right: 0.75rem;
   }
   
   span {
-    color: #6b7280;
+    color: var(--text-secondary);
     font-size: 0.875rem;
   }
 }
 
 .dropdown-footer {
   padding: 0.75rem 1rem;
-  border-top: 1px solid #f3f4f6;
+  border-top: 1px solid var(--border-secondary);
 }
 
 .view-all-btn {
   width: 100%;
   padding: 0.5rem 1rem;
-  background: #f9fafb;
-  border: 1px solid #e5e7eb;
+  background: var(--surface-secondary);
+  border: 1px solid var(--border-primary);
   border-radius: 0.375rem;
-  color: #374151;
+  color: var(--text-primary);
   font-size: 0.875rem;
   font-weight: 500;
   cursor: pointer;
   transition: all 0.2s ease;
   
   &:hover {
-    background: #f3f4f6;
-    border-color: #d1d5db;
+    background: var(--interactive-secondary);
+    border-color: var(--border-focus);
   }
   
   i {

--- a/components/ui/SuccessModal.vue
+++ b/components/ui/SuccessModal.vue
@@ -78,7 +78,7 @@ watch(
   left: 0;
   width: 100%;
   height: 100%;
-  background-color: rgba(0, 0, 0, 0.5);
+  background-color: var(--modal-backdrop);
   display: flex;
   justify-content: center;
   align-items: center;
@@ -87,14 +87,15 @@ watch(
 }
 
 .success-container {
-  background: white;
+  background: var(--modal-bg);
   border-radius: 16px;
   padding: 2rem;
   text-align: center;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--modal-shadow, var(--shadow-large));
   max-width: 350px;
   width: 90%;
   animation: bounceIn 0.6s ease-out;
+  border: 1px solid var(--border-primary);
 }
 
 .success-icon-wrapper {
@@ -106,13 +107,13 @@ watch(
 
 .success-title {
   font-size: 1.5rem;
-  color: #2c3e50;
+  color: var(--text-primary);
   margin: 0 0 0.5rem 0;
   font-weight: 600;
 }
 
 .success-message {
-  color: #666;
+  color: var(--text-secondary);
   margin: 0 0 1.5rem 0;
   line-height: 1.5;
 }
@@ -122,19 +123,19 @@ watch(
 }
 
 .btn-success {
-  background: linear-gradient(135deg, #28a745, #20c997);
-  color: white;
+  background: linear-gradient(135deg, var(--semantic-success), var(--interactive-primary));
+  color: var(--text-inverse);
   border: none;
   padding: 0.75rem 2rem;
   border-radius: 25px;
   font-size: 0.9rem;
   cursor: pointer;
   transition: all 0.3s ease;
-  box-shadow: 0 4px 15px rgba(40, 167, 69, 0.3);
+  box-shadow: var(--shadow-medium);
 
   &:hover {
     transform: translateY(-2px);
-    box-shadow: 0 6px 20px rgba(40, 167, 69, 0.4);
+    box-shadow: var(--shadow-large);
   }
 
   &:active {
@@ -188,8 +189,8 @@ watch(
   width: 80px;
   height: 80px;
   border-radius: 50%;
-  border: 4px solid rgba(40, 167, 69, 0.2); // 调整为绿色主题
-  border-left-color: #28a745;
+  border: 4px solid var(--surface-secondary);
+  border-left-color: var(--semantic-success);
   animation: animation_collect 1s linear 1 both;
 }
 
@@ -197,19 +198,19 @@ watch(
 @keyframes animation_collect {
   0% {
     transform: rotate(270deg);
-    border-left-color: #28a745;
+    border-left-color: var(--semantic-success);
   }
   25% {
-    border-left-color: #28a745;
+    border-left-color: var(--semantic-success);
   }
   50% {
-    border-left-color: #28a745;
+    border-left-color: var(--semantic-success);
   }
   75% {
-    border-left-color: #28a745;
+    border-left-color: var(--semantic-success);
   }
   100% {
-    border-left-color: rgba(40, 167, 69, 0.2);
+    border-left-color: var(--surface-secondary);
     transform: rotate(0deg);
   }
 }
@@ -220,7 +221,7 @@ watch(
   content: "";
   top: 50%;
   left: 15px;
-  border: 4px solid #28a745;
+  border: 4px solid var(--semantic-success);
   border-left-width: 0;
   border-bottom-width: 0;
   transform: scaleX(-1) rotate(135deg);
@@ -252,13 +253,13 @@ watch(
 
 .success-title {
   font-size: 1.5rem;
-  color: #2c3e50;
+  color: var(--text-primary);
   margin: 0 0 0.5rem 0;
   font-weight: 600;
 }
 
 .success-message {
-  color: #666;
+  color: var(--text-secondary);
   margin: 0 0 1.5rem 0;
   line-height: 1.5;
 }
@@ -268,19 +269,19 @@ watch(
 }
 
 .btn-success {
-  background: linear-gradient(135deg, #28a745, #20c997);
-  color: white;
+  background: linear-gradient(135deg, var(--semantic-success), var(--interactive-primary));
+  color: var(--text-inverse);
   border: none;
   padding: 0.75rem 2rem;
   border-radius: 25px;
   font-size: 0.9rem;
   cursor: pointer;
   transition: all 0.3s ease;
-  box-shadow: 0 4px 15px rgba(40, 167, 69, 0.3);
+  box-shadow: var(--shadow-medium);
 
   &:hover {
     transform: translateY(-2px);
-    box-shadow: 0 6px 20px rgba(40, 167, 69, 0.4);
+    box-shadow: var(--shadow-large);
   }
 
   &:active {

--- a/composables/useTheme.ts
+++ b/composables/useTheme.ts
@@ -1,0 +1,165 @@
+import { computed } from 'vue'
+import { useThemeStore } from '~/store/themeStore'
+
+/**
+ * Composable for accessing theme functionality in components
+ */
+export const useTheme = () => {
+  const themeStore = useThemeStore()
+
+  // Computed properties for easy access to theme state
+  const currentTheme = computed(() => themeStore.activeTheme)
+  const themeId = computed(() => themeStore.currentTheme)
+  const isLegacyTheme = computed(() => themeStore.isLegacyTheme)
+  const themeVariables = computed(() => themeStore.themeVariables)
+
+  // Helper methods
+  const setTheme = (themeId: string) => {
+    themeStore.setTheme(themeId)
+  }
+
+  const isDarkTheme = computed(() => {
+    return currentTheme.value?.category === 'dark'
+  })
+
+  const isLightTheme = computed(() => {
+    return currentTheme.value?.category === 'light'
+  })
+
+  const isColoredTheme = computed(() => {
+    return currentTheme.value?.category === 'colored'
+  })
+
+  // Get theme-aware component classes
+  const getThemeClasses = (componentType?: 'card' | 'button' | 'input' | 'modal') => {
+    const baseClasses = [`theme-${themeId.value}`]
+    
+    if (componentType) {
+      baseClasses.push(`${componentType}-themed`)
+    }
+    
+    if (isDarkTheme.value) {
+      baseClasses.push('dark-theme')
+    } else if (isLightTheme.value) {
+      baseClasses.push('light-theme')
+    } else {
+      baseClasses.push('colored-theme')
+    }
+    
+    return baseClasses
+  }
+
+  // Generate inline styles for theme variables
+  const getThemeStyles = () => {
+    return themeVariables.value
+  }
+
+  // Get theme-aware colors for specific use cases
+  const getThemeColors = () => {
+    if (!currentTheme.value) return {}
+    
+    return {
+      primary: currentTheme.value.colors.interactive.primary,
+      secondary: currentTheme.value.colors.interactive.secondary,
+      background: currentTheme.value.background.primary,
+      surface: currentTheme.value.colors.surface.primary,
+      text: currentTheme.value.colors.text.primary,
+      textSecondary: currentTheme.value.colors.text.secondary,
+      border: currentTheme.value.colors.border.primary,
+      success: currentTheme.value.colors.semantic.success,
+      warning: currentTheme.value.colors.semantic.warning,
+      error: currentTheme.value.colors.semantic.error,
+      info: currentTheme.value.colors.semantic.info
+    }
+  }
+
+  // Apply theme to specific element
+  const applyThemeToElement = (element: HTMLElement) => {
+    if (!element || !currentTheme.value) return
+    
+    const variables = generateCSSVariables(currentTheme.value)
+    Object.entries(variables).forEach(([property, value]) => {
+      element.style.setProperty(property, value)
+    })
+  }
+
+  // CSS-in-JS helper for dynamic styling
+  const createThemeStyles = (styles: Record<string, any>) => {
+    const colors = getThemeColors()
+    
+    // Replace theme color tokens with actual values
+    const processedStyles = { ...styles }
+    
+    Object.keys(processedStyles).forEach(key => {
+      let value = processedStyles[key]
+      
+      if (typeof value === 'string') {
+        value = value
+          .replace(/\$primary/g, colors.primary)
+          .replace(/\$secondary/g, colors.secondary)
+          .replace(/\$background/g, colors.background)
+          .replace(/\$surface/g, colors.surface)
+          .replace(/\$text/g, colors.text)
+          .replace(/\$textSecondary/g, colors.textSecondary)
+          .replace(/\$border/g, colors.border)
+          .replace(/\$success/g, colors.success)
+          .replace(/\$warning/g, colors.warning)
+          .replace(/\$error/g, colors.error)
+          .replace(/\$info/g, colors.info)
+        
+        processedStyles[key] = value
+      }
+    })
+    
+    return processedStyles
+  }
+
+  // Accessibility helpers
+  const getContrastColor = (backgroundColor: string) => {
+    // Simple contrast calculation - in production, use a proper color library
+    const rgb = backgroundColor.match(/\d+/g)
+    if (!rgb) return currentTheme.value?.colors.text.primary || '#000000'
+    
+    const brightness = (parseInt(rgb[0]) * 299 + parseInt(rgb[1]) * 587 + parseInt(rgb[2]) * 114) / 1000
+    return brightness > 128 
+      ? currentTheme.value?.colors.text.primary || '#000000'
+      : currentTheme.value?.colors.text.inverse || '#ffffff'
+  }
+
+  // Theme transition helpers
+  const enableThemeTransitions = () => {
+    if (process.client) {
+      document.body.style.transition = 'background-color 0.3s ease, color 0.3s ease'
+    }
+  }
+
+  const disableThemeTransitions = () => {
+    if (process.client) {
+      document.body.style.transition = ''
+    }
+  }
+
+  return {
+    // State
+    currentTheme,
+    themeId,
+    isLegacyTheme,
+    themeVariables,
+    
+    // Computed flags
+    isDarkTheme,
+    isLightTheme,
+    isColoredTheme,
+    
+    // Methods
+    setTheme,
+    getThemeClasses,
+    getThemeStyles,
+    getThemeColors,
+    applyThemeToElement,
+    createThemeStyles,
+    getContrastColor,
+    enableThemeTransitions,
+    disableThemeTransitions
+  }
+}

--- a/pages/courses/[id].vue
+++ b/pages/courses/[id].vue
@@ -890,8 +890,8 @@ useHead({
   .loading-spinner {
     width: 40px;
     height: 40px;
-    border: 4px solid #f3f3f3;
-    border-top: 4px solid #3498db;
+    border: 4px solid var(--border-secondary);
+    border-top: 4px solid var(--interactive-primary);
     border-radius: 50%;
     animation: spin 1s linear infinite;
   }
@@ -909,25 +909,26 @@ useHead({
 .error-state {
   text-align: center;
   padding: 3rem 2rem;
-  background-color: #fdf2f2;
-  border: 1px solid #fecaca;
+  background-color: var(--surface-primary);
+  border: 1px solid var(--semantic-error);
   border-radius: 8px;
   margin: 2rem auto;
   max-width: 600px;
+  box-shadow: var(--shadow-medium);
 
   i {
     font-size: 3rem;
-    color: #dc2626;
+    color: var(--semantic-error);
     margin-bottom: 1rem;
   }
 
   h2 {
-    color: #dc2626;
+    color: var(--semantic-error);
     margin-bottom: 1rem;
   }
 
   p {
-    color: #7f1d1d;
+    color: var(--text-secondary);
     margin-bottom: 1.5rem;
   }
 
@@ -949,33 +950,33 @@ useHead({
   }
 
   .retry-btn {
-    background-color: #dc2626;
-    color: white;
+    background-color: var(--semantic-error);
+    color: var(--text-inverse);
     &:hover {
-      background-color: #b91c1c;
+      opacity: 0.9;
     }
   }
 
   .back-btn {
-    background-color: #6b7280;
-    color: white;
+    background-color: var(--interactive-secondary);
+    color: var(--text-inverse);
     &:hover {
-      background-color: #4b5563;
+      background-color: var(--interactive-hover);
     }
   }
 }
 
 .course-detail-content {
-  background: white;
+  background: var(--card-bg);
   border-radius: 12px;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-large);
   overflow: hidden;
 }
 
 .course-header {
   padding: 2rem;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  color: white;
+  background: linear-gradient(135deg, var(--interactive-primary) 0%, var(--interactive-hover) 100%);
+  color: var(--text-inverse);
 }
 
 .course-title-section {
@@ -1014,27 +1015,27 @@ useHead({
 
 .course-description-section {
   padding: 2rem;
-  border-bottom: 1px solid #f0f0f0;
+  border-bottom: 1px solid var(--border-secondary);
 
   h3 {
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    color: #2c3e50;
+    color: var(--text-primary);
     margin-bottom: 1.5rem;
     font-size: 1.25rem;
 
     i {
-      color: #3498db;
+      color: var(--interactive-primary);
     }
   }
 }
 
 .course-description {
-  background: #f8f9fa;
+  background: var(--surface-secondary);
   padding: 1.5rem;
   border-radius: 8px;
-  color: #555;
+  color: var(--text-secondary);
   line-height: 1.6;
 }
 
@@ -1054,12 +1055,12 @@ useHead({
       display: flex;
       align-items: center;
       gap: 0.5rem;
-      color: #2c3e50;
+      color: var(--text-primary);
       font-size: 1.25rem;
       margin: 0;
 
       i {
-        color: #3498db;
+        color: var(--interactive-primary);
       }
 
       .reviews-count {
@@ -1113,7 +1114,7 @@ useHead({
 
 // 评价表单样式
 .review-form-section {
-  background: #f8f9fa;
+  background: var(--surface-secondary);
   border-radius: 12px;
   padding: 1.5rem;
   margin-bottom: 2rem;
@@ -1141,11 +1142,11 @@ useHead({
         align-items: center;
         gap: 0.5rem;
         font-weight: 600;
-        color: #2c3e50;
+        color: var(--text-primary);
         margin-bottom: 0.5rem;
 
         i {
-          color: #3498db;
+          color: var(--interactive-primary);
           width: 16px;
         }
       }
@@ -1155,15 +1156,17 @@ useHead({
       .form-textarea {
         width: 100%;
         padding: 0.75rem;
-        border: 2px solid #e1e8ed;
+        border: 2px solid var(--border-primary);
         border-radius: 8px;
         font-size: 1rem;
         font-family: inherit;
         transition: border-color 0.3s ease;
+        background: var(--surface-primary);
+        color: var(--text-primary);
 
         &:focus {
           outline: none;
-          border-color: #3498db;
+          border-color: var(--border-focus);
         }
       }
 
@@ -1175,13 +1178,13 @@ useHead({
       .char-count {
         text-align: right;
         font-size: 0.875rem;
-        color: #666;
+        color: var(--text-secondary);
         margin-top: 0.25rem;
       }
 
       .form-hint {
         font-size: 0.75rem;
-        color: #999;
+        color: var(--text-muted);
         margin-top: 0.25rem;
         font-style: italic;
       }
@@ -1190,7 +1193,7 @@ useHead({
         margin-top: 1rem;
         
         h4 {
-          color: #2c3e50;
+          color: var(--text-primary);
           margin-bottom: 1rem;
           font-size: 1rem;
           font-weight: 600;
@@ -1207,12 +1210,12 @@ useHead({
         position: relative;
         border-radius: 8px;
         overflow: hidden;
-        background: #f8f9fa;
-        border: 1px solid #e1e8ed;
+        background: var(--surface-primary);
+        border: 1px solid var(--border-primary);
         transition: all 0.3s ease;
 
         &:hover {
-          box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+          box-shadow: var(--shadow-medium);
         }
 
         .preview-img {
@@ -1231,7 +1234,7 @@ useHead({
 
           .filename {
             font-size: 0.75rem;
-            color: #666;
+            color: var(--text-secondary);
             overflow: hidden;
             text-overflow: ellipsis;
             white-space: nowrap;
@@ -1239,8 +1242,8 @@ useHead({
           }
 
           .remove-btn {
-            background: #dc3545;
-            color: white;
+            background: var(--semantic-error);
+            color: var(--text-inverse);
             border: none;
             border-radius: 50%;
             width: 24px;
@@ -1254,7 +1257,7 @@ useHead({
             transition: all 0.3s ease;
 
             &:hover {
-              background: #c82333;
+              opacity: 0.8;
               transform: scale(1.1);
             }
           }
@@ -1277,7 +1280,7 @@ useHead({
         background: none;
         border: none;
         font-size: 1.5rem;
-        color: #ddd;
+        color: var(--border-primary);
         cursor: pointer;
         transition: color 0.3s ease;
 
@@ -1288,20 +1291,20 @@ useHead({
       }
 
       .rating-text {
-        color: #666;
+        color: var(--text-secondary);
         font-size: 0.875rem;
       }
 
       .clear-rating {
         background: none;
         border: none;
-        color: #666;
+        color: var(--text-secondary);
         font-size: 0.875rem;
         cursor: pointer;
         text-decoration: underline;
 
         &:hover {
-          color: #dc2626;
+          color: var(--semantic-error);
         }
       }
     }
@@ -1338,20 +1341,20 @@ useHead({
   }
 
   &.btn-primary {
-    background: #3498db;
-    color: white;
+    background: var(--interactive-primary);
+    color: var(--text-inverse);
 
     &:hover:not(:disabled) {
-      background: #2980b9;
+      background: var(--interactive-hover);
     }
   }
 
   &.btn-secondary {
-    background: #6b7280;
-    color: white;
+    background: var(--interactive-secondary);
+    color: var(--text-inverse);
 
     &:hover {
-      background: #4b5563;
+      background: var(--interactive-hover);
     }
   }
 
@@ -1365,18 +1368,18 @@ useHead({
 .login-prompt {
   text-align: center;
   padding: 2rem;
-  background: #f8f9fa;
+  background: var(--surface-secondary);
   border-radius: 8px;
   margin-bottom: 2rem;
 
   i {
     font-size: 2rem;
-    color: #3498db;
+    color: var(--interactive-primary);
     margin-bottom: 1rem;
   }
 
   p {
-    color: #666;
+    color: var(--text-secondary);
     margin-bottom: 1rem;
   }
 }
@@ -1390,8 +1393,8 @@ useHead({
     .loading-spinner.small {
       width: 30px;
       height: 30px;
-      border: 4px solid #f3f3f3;
-      border-top: 4px solid #3498db;
+      border: 4px solid var(--border-secondary);
+      border-top: 4px solid var(--interactive-primary);
       border-radius: 50%;
       animation: spin 1s linear infinite;
     }
@@ -1400,7 +1403,7 @@ useHead({
   .no-reviews {
     text-align: center;
     padding: 3rem 2rem;
-    color: #666;
+    color: var(--text-secondary);
 
     i {
       font-size: 3rem;
@@ -1416,17 +1419,17 @@ useHead({
   }
 
   .review-item {
-    background: white;
-    border: 1px solid #e1e8ed;
+    background: var(--card-bg);
+    border: 1px solid var(--border-primary);
     border-radius: 12px;
     padding: 1.5rem;
     cursor: pointer;
     transition: all 0.3s ease;
 
     &:hover {
-      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+      box-shadow: var(--shadow-medium);
       transform: translateY(-2px);
-      border-color: #3498db;
+      border-color: var(--interactive-primary);
     }
 
     .review-header {
@@ -1445,17 +1448,17 @@ useHead({
 
         .reviewer-name {
           font-weight: 600;
-          color: #2c3e50;
+          color: var(--text-primary);
         }
 
         .review-date {
-          color: #666;
+          color: var(--text-secondary);
           font-size: 0.875rem;
         }
 
         .review-semester {
-          background: #e3f2fd;
-          color: #1565c0;
+          background: rgba(59, 130, 246, 0.1);
+          color: var(--interactive-primary);
           padding: 0.125rem 0.5rem;
           border-radius: 12px;
           font-size: 0.75rem;
@@ -1473,7 +1476,7 @@ useHead({
 
           i {
             font-size: 0.875rem;
-            color: #ddd;
+            color: var(--border-primary);
 
             &.active {
               color: #ffd700;
@@ -1484,13 +1487,13 @@ useHead({
         .rating-number {
           font-size: 0.875rem;
           font-weight: 600;
-          color: #2c3e50;
+          color: var(--text-primary);
         }
       }
     }
 
     .review-content {
-      color: #2c3e50;
+      color: var(--text-primary);
       line-height: 1.6;
       margin-bottom: 1rem;
       white-space: pre-wrap;
@@ -1503,7 +1506,7 @@ useHead({
       .action-btn {
         background: none;
         border: none;
-        color: #666;
+        color: var(--text-secondary);
         font-size: 0.875rem;
         cursor: pointer;
         display: flex;
@@ -1514,21 +1517,21 @@ useHead({
         transition: all 0.3s ease;
 
         &:hover {
-          background: #f8f9fa;
-          color: #2c3e50;
+          background: var(--surface-secondary);
+          color: var(--text-primary);
         }
 
         &.liked {
-          color: #3498db;
+          color: var(--interactive-primary);
         }
 
         &.view-detail-btn {
-          color: #3498db;
+          color: var(--interactive-primary);
           font-weight: 500;
           
           &:hover {
-            background: #e3f2fd;
-            color: #1976d2;
+            background: rgba(59, 130, 246, 0.1);
+            color: var(--interactive-hover);
           }
         }
       }
@@ -1540,20 +1543,22 @@ useHead({
 .reply-form {
   margin-top: 1rem;
   padding-top: 1rem;
-  border-top: 1px solid #e1e8ed;
+  border-top: 1px solid var(--border-primary);
 
   .reply-textarea {
     width: 100%;
     padding: 0.75rem;
-    border: 2px solid #e1e8ed;
+    border: 2px solid var(--border-primary);
     border-radius: 8px;
     resize: vertical;
     font-family: inherit;
     margin-bottom: 0.5rem;
+    background: var(--surface-primary);
+    color: var(--text-primary);
 
     &:focus {
       outline: none;
-      border-color: #3498db;
+      border-color: var(--border-focus);
     }
   }
 
@@ -1567,10 +1572,10 @@ useHead({
 .replies-list {
   margin-top: 1rem;
   padding-top: 1rem;
-  border-top: 1px solid #e1e8ed;
+  border-top: 1px solid var(--border-primary);
 
   .reply-item {
-    background: #f8f9fa;
+    background: var(--surface-secondary);
     border-radius: 8px;
     padding: 1rem;
     margin-bottom: 0.75rem;
@@ -1586,18 +1591,18 @@ useHead({
 
       .reply-author {
         font-weight: 600;
-        color: #2c3e50;
+        color: var(--text-primary);
         font-size: 0.875rem;
       }
 
       .reply-date {
-        color: #666;
+        color: var(--text-secondary);
         font-size: 0.75rem;
       }
     }
 
     .reply-content {
-      color: #555;
+      color: var(--text-secondary);
       line-height: 1.5;
       font-size: 0.875rem;
     }

--- a/pages/courses/index.vue
+++ b/pages/courses/index.vue
@@ -201,7 +201,7 @@ onMounted(() => {
 
   h1 {
     font-size: 2rem;
-    color: #2c3e50;
+    color: var(--text-primary);
     margin-bottom: 1.5rem;
     
     // Mobile optimization
@@ -252,17 +252,19 @@ onMounted(() => {
   input {
     width: 100%;
     padding: 0.75rem 1rem 0.75rem 2.5rem;
-    border: 1px solid #e0e0e0;
+    border: 1px solid var(--border-primary);
     border-radius: 8px;
     font-size: 1rem;
     transition: all 0.3s ease;
+    background: var(--surface-primary);
+    color: var(--text-primary);
     // Ensure touch-friendly input height
     min-height: 44px;
     box-sizing: border-box;
 
     &:focus {
-      border-color: #3498db;
-      box-shadow: 0 0 0 2px rgba(52, 152, 219, 0.2);
+      border-color: var(--border-focus);
+      box-shadow: 0 0 0 2px var(--interactive-primary);
       outline: none;
     }
     
@@ -278,7 +280,7 @@ onMounted(() => {
     left: 1rem;
     top: 50%;
     transform: translateY(-50%);
-    color: #95a5a6;
+    color: var(--text-muted);
     // Ensure touch target is large enough
     width: 20px;
     height: 20px;
@@ -299,10 +301,11 @@ onMounted(() => {
 
   select {
     padding: 0.75rem 1rem;
-    border: 1px solid #e0e0e0;
+    border: 1px solid var(--border-primary);
     border-radius: 8px;
     font-size: 1rem;
-    background-color: white;
+    background-color: var(--surface-primary);
+    color: var(--text-primary);
     cursor: pointer;
     transition: all 0.3s ease;
     // Ensure touch-friendly select height
@@ -310,7 +313,7 @@ onMounted(() => {
     box-sizing: border-box;
 
     &:focus {
-      border-color: #3498db;
+      border-color: var(--border-focus);
       outline: none;
     }
     
@@ -359,22 +362,23 @@ onMounted(() => {
 }
 
 .course-card {
-  background: white;
+  background: var(--card-bg);
   border-radius: 12px;
   padding: 1.5rem;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--card-shadow, var(--shadow-small));
   transition: transform 0.3s ease, box-shadow 0.3s ease;
   text-decoration: none;
   color: inherit;
   display: block;
   cursor: pointer;
+  border: var(--card-border, 1px solid var(--border-primary));
   // Ensure minimum touch target size
   min-height: 44px;
   position: relative;
 
   &:hover {
     transform: translateY(-4px);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    box-shadow: var(--shadow-medium);
     text-decoration: none;
     color: inherit;
   }
@@ -387,7 +391,7 @@ onMounted(() => {
     // Adjust hover effect for mobile
     &:hover {
       transform: translateY(-2px);
-      box-shadow: 0 3px 10px rgba(0, 0, 0, 0.12);
+      box-shadow: var(--shadow-small);
     }
   }
   
@@ -398,7 +402,7 @@ onMounted(() => {
     // Remove hover transform on small screens to prevent layout issues
     &:hover {
       transform: none;
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+      box-shadow: var(--shadow-small);
     }
     
     // Add active state for touch feedback
@@ -418,7 +422,7 @@ onMounted(() => {
 
   .course-code {
     font-size: 1.25rem;
-    color: #2c3e50;
+    color: var(--text-primary);
     margin: 0;
     flex: 1;
     min-width: 0; // Allow text to truncate
@@ -434,8 +438,8 @@ onMounted(() => {
   }
 
   .course-credits {
-    background: #e3f2fd;
-    color: #1976d2;
+    background: var(--surface-secondary);
+    color: var(--interactive-primary);
     padding: 0.25rem 0.75rem;
     border-radius: 16px;
     font-size: 0.875rem;
@@ -464,7 +468,7 @@ onMounted(() => {
 
 .course-name {
   font-size: 1.125rem;
-  color: #34495e;
+  color: var(--text-secondary);
   margin: 0 0 0.75rem 0;
   line-height: 1.4;
   
@@ -482,7 +486,7 @@ onMounted(() => {
 }
 
 .course-description {
-  color: #666;
+  color: var(--text-muted);
   font-size: 0.875rem;
   margin-bottom: 1.5rem;
   line-height: 1.5;
@@ -501,7 +505,7 @@ onMounted(() => {
   gap: 0.5rem;
 
   .instructor {
-    color: #666;
+    color: var(--text-muted);
     font-size: 0.875rem;
     flex: 1;
     min-width: 0; // Allow text to truncate
@@ -513,7 +517,7 @@ onMounted(() => {
   }
 
   .view-course-hint {
-    color: #3498db;
+    color: var(--interactive-primary);
     font-size: 0.875rem;
     font-weight: 500;
     opacity: 0.8;
@@ -545,23 +549,23 @@ onMounted(() => {
   align-items: center;
   justify-content: center;
   padding: 3rem;
-  color: #666;
+  color: var(--text-muted);
 
   i {
     font-size: 2rem;
     margin-bottom: 1rem;
-    color: #3498db;
+    color: var(--interactive-primary);
   }
 }
 
 .no-courses {
   text-align: center;
   padding: 3rem;
-  color: #666;
+  color: var(--text-muted);
 
   i {
     font-size: 3rem;
-    color: #95a5a6;
+    color: var(--text-muted);
     margin-bottom: 1rem;
   }
 

--- a/pages/forum/posts/[id].vue
+++ b/pages/forum/posts/[id].vue
@@ -365,9 +365,9 @@ onMounted(() => {
 .post-reactions {
   margin: 2rem 0;
   padding: 1.5rem 0;
-  border-top: 1px solid #f0f0f0;
-  border-bottom: 1px solid #f0f0f0;
-  background: rgba(248, 249, 250, 0.5);
+  border-top: 1px solid var(--border-secondary);
+  border-bottom: 1px solid var(--border-secondary);
+  background: var(--surface-secondary);
   border-radius: 8px;
   padding: 1.5rem;
 }
@@ -375,10 +375,10 @@ onMounted(() => {
 .post-container {
   max-width: 800px;
   margin: 0 auto;
-  background-color: rgba(255, 255, 255, 0.7);
+  background-color: var(--card-bg);
   border-radius: 8px;
   padding: 1.5rem;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-medium);
   
   // Mobile responsiveness
   @media (max-width: 480px) {
@@ -386,7 +386,7 @@ onMounted(() => {
     border-radius: 0;
     padding: 1rem;
     box-shadow: none;
-    background-color: rgba(255, 255, 255, 0.9);
+    background-color: var(--card-bg);
   }
   
   @media (min-width: 481px) and (max-width: 768px) {
@@ -403,28 +403,29 @@ onMounted(() => {
   text-align: center;
   padding: 2rem;
   font-size: 1.2rem;
-  color: #666;
+  color: var(--text-secondary);
 }
 
 .error {
   text-align: center;
   padding: 2rem;
-  color: #e74c3c;
-  background-color: #ffebee;
-  border-radius: 4px;
+  color: var(--semantic-error);
+  background-color: var(--surface-secondary);
+  border: 1px solid var(--semantic-error);
+  border-radius: 8px;
   margin-bottom: 1rem;
 }
 
 .post-header {
   margin-bottom: 2rem;
-  border-bottom: 1px solid #e0e0e0;
+  border-bottom: 1px solid var(--border-primary);
   padding-bottom: 1rem;
 }
 
 .post-title {
   font-size: 2rem;
   margin-bottom: 0.5rem;
-  color: #2c3e50;
+  color: var(--text-primary);
   line-height: 1.3;
   word-wrap: break-word;
   
@@ -444,7 +445,7 @@ onMounted(() => {
 .post-meta {
   display: flex;
   gap: 1rem;
-  color: #666;
+  color: var(--text-secondary);
   font-size: 0.9rem;
   flex-wrap: wrap;
   align-items: center;
@@ -474,7 +475,7 @@ onMounted(() => {
   
   .author {
     font-weight: 500;
-    color: #2c3e50;
+    color: var(--text-primary);
     
     @media (max-width: 480px) {
       font-size: 0.9rem;
@@ -502,8 +503,8 @@ onMounted(() => {
 
   .tag {
     font-size: 0.8rem;
-    background-color: #edf2f7;
-    color: #3182ce;
+    background-color: var(--surface-secondary);
+    color: var(--interactive-primary);
     padding: 0.2rem 0.6rem;
     border-radius: 4px;
     
@@ -567,13 +568,13 @@ onMounted(() => {
     .image-item {
       border-radius: 8px;
       overflow: hidden;
-      background: #f5f5f5;
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+      background: var(--surface-secondary);
+      box-shadow: var(--shadow-small);
       transition: transform 0.3s ease, box-shadow 0.3s ease;
       
       &:hover {
         transform: translateY(-2px);
-        box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+        box-shadow: var(--shadow-medium);
       }
       
       .image-container {
@@ -589,7 +590,7 @@ onMounted(() => {
           cursor: pointer;
           transition: opacity 0.3s ease;
           display: block;
-          background: white;
+          background: var(--surface-primary);
           
           // Mobile-optimized image sizes
           @media (max-width: 480px) {
@@ -620,7 +621,7 @@ onMounted(() => {
           left: 0;
           right: 0;
           background: linear-gradient(transparent, rgba(0, 0, 0, 0.7));
-          color: white;
+          color: var(--text-inverse);
           padding: 0.5rem;
           transform: translateY(100%);
           transition: transform 0.3s ease;
@@ -664,7 +665,7 @@ onMounted(() => {
     gap: 0.5rem;
     padding: 0.5rem 1rem;
     border: none;
-    background-color: #f0f0f0;
+    background-color: var(--surface-secondary);
     border-radius: 4px;
     cursor: pointer;
     transition: all 0.3s ease;
@@ -683,7 +684,7 @@ onMounted(() => {
     }
 
     &:hover {
-      background-color: #e0e0e0;
+      background-color: var(--surface-elevated);
       transform: translateY(-1px);
     }
     
@@ -694,17 +695,17 @@ onMounted(() => {
 
     // Delete button styling
     &.delete-button {
-      background-color: #ffebee;
-      color: #d32f2f;
-      border: 1px solid #ffcdd2;
+      background-color: rgba(239, 68, 68, 0.1);
+      color: var(--semantic-error);
+      border: 1px solid var(--semantic-error);
 
       &:hover {
-        background-color: #ffcdd2;
-        box-shadow: 0 4px 12px rgba(211, 47, 47, 0.2);
+        background-color: rgba(239, 68, 68, 0.2);
+        box-shadow: 0 4px 12px rgba(239, 68, 68, 0.2);
       }
       
       &:active {
-        background-color: #ffb3ba;
+        background-color: rgba(239, 68, 68, 0.3);
       }
     }
   }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -317,14 +317,34 @@ onUnmounted(() => {
 
 // 欢迎区域
 .welcome-section {
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  background: linear-gradient(135deg, var(--interactive-primary) 0%, var(--interactive-hover) 100%);
   border-radius: 20px;
   padding: 3rem 2rem;
   color: white;
   margin-bottom: 3rem;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-large);
   display: grid;
   gap: 2rem;
+  position: relative;
+  overflow: hidden;
+  
+  // Add a subtle overlay to ensure text readability
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.1);
+    z-index: 1;
+  }
+  
+  // Ensure content is above the overlay
+  > * {
+    position: relative;
+    z-index: 2;
+  }
   
   // Desktop layout - side by side
   grid-template-columns: 2fr 1fr;
@@ -393,18 +413,18 @@ onUnmounted(() => {
 
   // External links sidebar
   .external-links-sidebar {
-    background: rgba(255, 255, 255, 0.15);
+    background: var(--surface-overlay);
     border-radius: 15px;
     padding: 1.5rem;
-    backdrop-filter: blur(10px);
-    border: 1px solid rgba(255, 255, 255, 0.2);
+    backdrop-filter: var(--effect-blur);
+    border: 1px solid var(--border-secondary);
     
     .sidebar-title {
       font-size: 1.2rem;
       font-weight: 600;
       margin-bottom: 1rem;
       text-align: center;
-      color: white;
+      color: var(--text-primary);
       
       @media (min-width: 1025px) {
         text-align: left;
@@ -418,27 +438,30 @@ onUnmounted(() => {
     }
 
     .external-link-sidebar {
-      background: rgba(255, 255, 255, 0.1);
+      background: var(--surface-secondary);
       padding: 0.75rem;
       border-radius: 10px;
       text-decoration: none;
-      color: white;
+      color: var(--text-primary);
       transition: all 0.3s ease;
       display: flex;
       align-items: center;
       gap: 0.75rem;
       font-size: 0.9rem;
-      border: 1px solid rgba(255, 255, 255, 0.1);
+      border: 1px solid var(--border-primary);
+      backdrop-filter: blur(10px);
+      box-shadow: var(--shadow-small);
 
       &:hover {
-        background: rgba(255, 255, 255, 0.2);
+        background: var(--interactive-secondary);
         transform: translateY(-1px);
-        border-color: rgba(255, 255, 255, 0.3);
+        border-color: var(--border-focus);
+        box-shadow: var(--shadow-medium);
       }
 
       i:first-child {
         font-size: 1rem;
-        color: #ffd700;
+        color: var(--semantic-warning);
         flex-shrink: 0;
         width: 16px;
         text-align: center;
@@ -448,25 +471,27 @@ onUnmounted(() => {
         font-weight: 500;
         flex-grow: 1;
         font-size: 0.85rem;
+        color: var(--text-primary);
       }
 
       .external-icon {
         font-size: 0.7rem;
-        opacity: 0.7;
+        opacity: 0.8;
         flex-shrink: 0;
+        color: var(--text-secondary);
       }
 
       // Different hover colors for each link
       &:nth-child(1):hover {
-        background: rgba(40, 167, 69, 0.2);
+        background: var(--semantic-success);
       }
 
       &:nth-child(2):hover {
-        background: rgba(255, 193, 7, 0.2);
+        background: var(--semantic-warning);
       }
 
       &:nth-child(3):hover {
-        background: rgba(220, 53, 69, 0.2);
+        background: var(--semantic-error);
       }
     }
   }
@@ -490,35 +515,37 @@ onUnmounted(() => {
   min-width: 44px;
 
   &.btn-primary {
-    background: #ff6b6b;
-    color: white;
+    background: var(--interactive-primary);
+    color: var(--text-inverse);
     
     &:hover {
-      background: #ff5252;
+      background: var(--interactive-hover);
       transform: translateY(-2px);
-      box-shadow: 0 5px 15px rgba(255, 107, 107, 0.4);
+      box-shadow: var(--shadow-medium);
     }
   }
 
   &.btn-secondary {
-    background: rgba(255, 255, 255, 0.2);
+    background: rgba(255, 255, 255, 0.15);
     color: white;
     border: 2px solid rgba(255, 255, 255, 0.3);
+    backdrop-filter: blur(10px);
     
     &:hover {
-      background: rgba(255, 255, 255, 0.3);
+      background: rgba(255, 255, 255, 0.25);
+      border-color: rgba(255, 255, 255, 0.5);
       transform: translateY(-2px);
     }
   }
 
   &.btn-outline {
     background: transparent;
-    color: #667eea;
-    border: 2px solid #667eea;
+    color: var(--interactive-primary);
+    border: 2px solid var(--interactive-primary);
     
     &:hover {
-      background: #667eea;
-      color: white;
+      background: var(--interactive-primary);
+      color: var(--text-inverse);
     }
   }
 }
@@ -527,27 +554,27 @@ onUnmounted(() => {
 .section-title {
   font-size: 1.8rem;
   font-weight: 700;
-  color: #2c3e50;
+  color: var(--text-primary);
   margin-bottom: 1.5rem;
   display: flex;
   align-items: center;
   gap: 0.5rem;
 
   i {
-    color: #ff6b6b;
+    color: var(--interactive-primary);
   }
 
   .refresh-indicator {
     margin-left: auto;
     font-size: 0.875rem;
     font-weight: 400;
-    color: #666;
+    color: var(--text-muted);
     display: flex;
     align-items: center;
     gap: 0.25rem;
 
     i {
-      color: #666;
+      color: var(--text-muted);
       font-size: 0.75rem;
     }
   }
@@ -560,9 +587,9 @@ onUnmounted(() => {
   .loading-state, .error-state, .empty-state {
     text-align: center;
     padding: 3rem 2rem;
-    background: rgba(255, 255, 255, 0.7);
+    background: var(--card-bg);
     border-radius: 15px;
-    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+    box-shadow: var(--shadow-medium);
 
     i {
       font-size: 3rem;
@@ -573,8 +600,8 @@ onUnmounted(() => {
     .loading-spinner {
       width: 40px;
       height: 40px;
-      border: 4px solid #f3f3f3;
-      border-top: 4px solid #667eea;
+      border: 4px solid var(--border-secondary);
+      border-top: 4px solid var(--interactive-primary);
       border-radius: 50%;
       animation: spin 1s linear infinite;
       margin: 0 auto 1rem;
@@ -607,19 +634,19 @@ onUnmounted(() => {
   }
 
   .post-card {
-    background: rgba(255, 255, 255, 0.9);
+    background: var(--card-bg);
     border-radius: 15px;
     padding: 1.5rem;
     cursor: pointer;
     transition: all 0.3s ease;
-    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.08);
-    border: 1px solid rgba(255, 255, 255, 0.2);
+    box-shadow: var(--card-shadow, var(--shadow-small));
+    border: var(--card-border, 1px solid var(--border-primary));
     // Ensure proper touch targets
     min-height: 44px;
 
     &:hover {
       transform: translateY(-5px);
-      box-shadow: 0 8px 25px rgba(0, 0, 0, 0.15);
+      box-shadow: var(--shadow-large);
     }
 
     // Reduce hover effects on mobile for better performance
@@ -631,7 +658,7 @@ onUnmounted(() => {
       // Add active state for better mobile feedback
       &:active {
         transform: translateY(0);
-        box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+        box-shadow: var(--shadow-small);
       }
     }
 
@@ -645,7 +672,7 @@ onUnmounted(() => {
       .post-title {
         font-size: 1.1rem;
         font-weight: 600;
-        color: #2c3e50;
+        color: var(--text-primary);
         margin: 0;
         flex: 1;
         line-height: 1.4;
@@ -655,8 +682,8 @@ onUnmounted(() => {
       }
 
       .post-score {
-        background: linear-gradient(45deg, #ff6b6b, #ffa726);
-        color: white;
+        background: linear-gradient(45deg, var(--interactive-primary), var(--semantic-warning));
+        color: var(--text-inverse);
         padding: 0.25rem 0.5rem;
         border-radius: 12px;
         font-size: 0.75rem;
@@ -680,7 +707,7 @@ onUnmounted(() => {
       min-height: 32px;
       
       .author-name {
-        color: #555;
+        color: var(--text-secondary);
         font-weight: 500;
         // Prevent text overflow on mobile
         overflow: hidden;
@@ -690,7 +717,7 @@ onUnmounted(() => {
     }
 
     .post-content {
-      color: #555;
+      color: var(--text-secondary);
       line-height: 1.5;
       margin-bottom: 1rem;
       font-size: 0.9rem;
@@ -721,18 +748,18 @@ onUnmounted(() => {
         align-items: center;
 
         &.course {
-          background: #e3f2fd;
-          color: #1565c0;
+          background: var(--surface-secondary);
+          color: var(--semantic-info);
         }
 
         &.user {
-          background: #f3e5f5;
-          color: #7b1fa2;
+          background: var(--surface-elevated);
+          color: var(--interactive-primary);
         }
 
         &.system {
-          background: #e8f5e8;
-          color: #2e7d32;
+          background: var(--surface-overlay);
+          color: var(--semantic-success);
         }
       }
     }
@@ -742,7 +769,7 @@ onUnmounted(() => {
       align-items: center;
       gap: 1rem;
       font-size: 0.875rem;
-      color: #666;
+      color: var(--text-muted);
       flex-wrap: wrap;
 
       .stat {
@@ -753,14 +780,14 @@ onUnmounted(() => {
         min-height: 24px;
 
         i {
-          color: #999;
+          color: var(--text-muted);
         }
       }
 
       .post-time {
         margin-left: auto;
         font-size: 0.8rem;
-        color: #999;
+        color: var(--text-muted);
       }
     }
   }
@@ -793,14 +820,14 @@ onUnmounted(() => {
     }
 
     .quick-link {
-      background: rgba(255, 255, 255, 0.8);
+      background: var(--card-bg);
       padding: 2rem 1rem;
       border-radius: 15px;
       text-decoration: none;
-      color: #2c3e50;
+      color: var(--text-primary);
       text-align: center;
       transition: all 0.3s ease;
-      box-shadow: 0 4px 15px rgba(0, 0, 0, 0.08);
+      box-shadow: var(--shadow-small);
       // Ensure proper touch targets
       min-height: 120px;
       display: flex;
@@ -810,8 +837,8 @@ onUnmounted(() => {
 
       &:hover {
         transform: translateY(-3px);
-        box-shadow: 0 6px 20px rgba(0, 0, 0, 0.12);
-        background: rgba(255, 255, 255, 0.95);
+        box-shadow: var(--shadow-medium);
+        background: var(--surface-elevated);
       }
 
       // Reduce hover effects on mobile
@@ -831,7 +858,7 @@ onUnmounted(() => {
       i {
         font-size: 2rem;
         margin-bottom: 0.5rem;
-        color: #667eea;
+        color: var(--interactive-primary);
         display: block;
         
         // Smaller icons on mobile

--- a/pages/search/index.vue
+++ b/pages/search/index.vue
@@ -500,7 +500,7 @@ onMounted(() => {
 <style lang="scss" scoped>
 .search-page {
   min-height: calc(100vh - 120px);
-  background: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
+  background: var(--bg-primary);
   padding: 2rem 0;
 }
 
@@ -523,18 +523,18 @@ onMounted(() => {
   align-items: center;
   gap: 0.5rem;
   padding: 0.5rem 1rem;
-  background: white;
-  border: 1px solid #e5e7eb;
+  background: var(--surface-primary);
+  border: 1px solid var(--border-primary);
   border-radius: 0.5rem;
-  color: #374151;
+  color: var(--text-primary);
   cursor: pointer;
   transition: all 0.2s ease;
   font-size: 0.875rem;
   font-weight: 500;
   
   &:hover {
-    background: #f9fafb;
-    border-color: #d1d5db;
+    background: var(--surface-secondary);
+    border-color: var(--border-secondary);
     transform: translateX(-2px);
   }
   
@@ -547,35 +547,36 @@ onMounted(() => {
   display: flex;
   align-items: center;
   font-size: 0.875rem;
-  color: #6b7280;
+  color: var(--text-secondary);
   
   .breadcrumb-item {
-    color: #6b7280;
+    color: var(--text-secondary);
     text-decoration: none;
     transition: color 0.2s ease;
     
     &:hover:not(.current) {
-      color: #3b82f6;
+      color: var(--interactive-primary);
     }
     
     &.current {
-      color: #1f2937;
+      color: var(--text-primary);
       font-weight: 500;
     }
   }
   
   .breadcrumb-separator {
     margin: 0 0.5rem;
-    color: #d1d5db;
+    color: var(--text-muted);
   }
 }
 
 .search-header {
-  background: white;
+  background: var(--card-bg);
   border-radius: 12px;
   padding: 1.5rem;
   margin-bottom: 1.5rem;
-  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--card-shadow);
+  border: var(--card-border);
 }
 
 .search-input-section {
@@ -587,26 +588,27 @@ onMounted(() => {
   align-items: center;
   justify-content: space-between;
   font-size: 0.875rem;
-  color: #6b7280;
+  color: var(--text-secondary);
   
   .search-query {
     strong {
-      color: #1f2937;
+      color: var(--text-primary);
     }
   }
   
   .result-count {
-    color: #059669;
+    color: var(--semantic-success);
   }
 }
 
 .search-tabs {
   display: flex;
-  background: white;
+  background: var(--card-bg);
   border-radius: 12px;
   padding: 0.5rem;
   margin-bottom: 1.5rem;
-  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--card-shadow);
+  border: var(--card-border);
   gap: 0.5rem;
 }
 
@@ -620,23 +622,23 @@ onMounted(() => {
   transition: all 0.2s ease;
   font-size: 0.875rem;
   font-weight: 500;
-  color: #6b7280;
+  color: var(--text-secondary);
   
   i {
     margin-right: 0.5rem;
   }
   
   &:hover {
-    background: #f9fafb;
-    color: #374151;
+    background: var(--interactive-secondary);
+    color: var(--text-primary);
   }
   
   &.active {
-    background: #3b82f6;
-    color: white;
+    background: var(--interactive-primary);
+    color: var(--text-inverse);
     
     &:hover {
-      background: #2563eb;
+      background: var(--interactive-hover);
     }
   }
 }
@@ -647,51 +649,54 @@ onMounted(() => {
   gap: 0.5rem;
   margin-bottom: 1.5rem;
   font-size: 0.875rem;
-  color: #6b7280;
+  color: var(--text-secondary);
   
   .sort-select {
     padding: 0.375rem 0.75rem;
-    border: 1px solid #d1d5db;
+    border: 1px solid var(--border-primary);
     border-radius: 0.375rem;
-    background: white;
+    background: var(--surface-primary);
+    color: var(--text-primary);
     font-size: 0.875rem;
     
     &:focus {
       outline: none;
-      border-color: #3b82f6;
+      border-color: var(--border-focus);
       box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
     }
   }
 }
 
 .loading-state, .error-state, .no-results, .empty-state {
-  background: white;
+  background: var(--card-bg);
   border-radius: 12px;
   padding: 3rem 2rem;
   text-align: center;
-  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--card-shadow);
+  border: var(--card-border);
   
   i {
     font-size: 3rem;
     margin-bottom: 1rem;
     opacity: 0.5;
+    color: var(--text-muted);
   }
   
   h3 {
     margin: 0 0 0.5rem;
-    color: #1f2937;
+    color: var(--text-primary);
   }
   
   p {
-    color: #6b7280;
+    color: var(--text-secondary);
     margin: 0;
   }
   
   .loading-spinner {
     width: 40px;
     height: 40px;
-    border: 4px solid #f3f3f3;
-    border-top: 4px solid #3b82f6;
+    border: 4px solid var(--border-secondary);
+    border-top: 4px solid var(--interactive-primary);
     border-radius: 50%;
     animation: spin 1s linear infinite;
     margin: 0 auto 1rem;
@@ -700,14 +705,14 @@ onMounted(() => {
   .retry-btn {
     margin-top: 1rem;
     padding: 0.5rem 1rem;
-    background: #3b82f6;
-    color: white;
+    background: var(--interactive-primary);
+    color: var(--text-inverse);
     border: none;
     border-radius: 0.375rem;
     cursor: pointer;
     
     &:hover {
-      background: #2563eb;
+      background: var(--interactive-hover);
     }
   }
   
@@ -723,17 +728,17 @@ onMounted(() => {
     align-items: center;
     gap: 0.5rem;
     padding: 0.75rem 1.5rem;
-    background: white;
-    border: 2px solid #e5e7eb;
+    background: var(--surface-primary);
+    border: 2px solid var(--border-primary);
     border-radius: 0.5rem;
-    color: #374151;
+    color: var(--text-primary);
     text-decoration: none;
     font-weight: 500;
     transition: all 0.2s ease;
     
     &:hover {
-      border-color: #3b82f6;
-      color: #3b82f6;
+      border-color: var(--interactive-primary);
+      color: var(--interactive-primary);
       transform: translateY(-2px);
       box-shadow: 0 4px 12px rgba(59, 130, 246, 0.15);
     }
@@ -753,7 +758,7 @@ onMounted(() => {
   
   h4 {
     margin: 0 0 0.5rem;
-    color: #374151;
+    color: var(--text-primary);
     font-size: 1rem;
   }
   
@@ -764,12 +769,12 @@ onMounted(() => {
     
     li {
       padding: 0.25rem 0;
-      color: #6b7280;
+      color: var(--text-secondary);
       font-size: 0.875rem;
       
       &:before {
         content: "•";
-        color: #3b82f6;
+        color: var(--interactive-primary);
         margin-right: 0.5rem;
       }
     }
@@ -777,22 +782,23 @@ onMounted(() => {
 }
 
 .search-results {
-  background: white;
+  background: var(--card-bg);
   border-radius: 12px;
   overflow: hidden;
-  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--card-shadow);
+  border: var(--card-border);
 }
 
 // Posts results styling
 .posts-results {
   .post-result {
     padding: 1.5rem;
-    border-bottom: 1px solid #f3f4f6;
+    border-bottom: 1px solid var(--border-secondary);
     cursor: pointer;
     transition: background-color 0.2s ease;
     
     &:hover {
-      background: #f9fafb;
+      background: var(--interactive-secondary);
     }
     
     &:last-child {
@@ -802,7 +808,7 @@ onMounted(() => {
     .post-title {
       font-size: 1.125rem;
       font-weight: 600;
-      color: #1f2937;
+      color: var(--text-primary);
       margin: 0 0 0.5rem;
       line-height: 1.4;
       
@@ -815,7 +821,7 @@ onMounted(() => {
     }
     
     .post-excerpt {
-      color: #6b7280;
+      color: var(--text-secondary);
       margin: 0 0 1rem;
       line-height: 1.5;
     }
@@ -833,7 +839,7 @@ onMounted(() => {
         
         .author-name {
           font-weight: 500;
-          color: #374151;
+          color: var(--text-primary);
           font-size: 0.875rem;
         }
       }
@@ -843,7 +849,7 @@ onMounted(() => {
         align-items: center;
         gap: 1rem;
         font-size: 0.75rem;
-        color: #9ca3af;
+        color: var(--text-muted);
         
         .stat {
           display: flex;
@@ -869,18 +875,18 @@ onMounted(() => {
         font-weight: 500;
         
         &.course {
-          background: #dbeafe;
-          color: #1d4ed8;
+          background: var(--interactive-secondary);
+          color: var(--interactive-primary);
         }
         
         &.user {
-          background: #fce7f3;
-          color: #be185d;
+          background: var(--surface-secondary);
+          color: var(--semantic-info);
         }
         
         &.system {
-          background: #d1fae5;
-          color: #047857;
+          background: var(--surface-secondary);
+          color: var(--semantic-success);
         }
       }
     }
@@ -893,12 +899,12 @@ onMounted(() => {
     display: flex;
     align-items: center;
     padding: 1.5rem;
-    border-bottom: 1px solid #f3f4f6;
+    border-bottom: 1px solid var(--border-secondary);
     cursor: pointer;
     transition: background-color 0.2s ease;
     
     &:hover {
-      background: #f9fafb;
+      background: var(--interactive-secondary);
     }
     
     &:last-child {
@@ -911,7 +917,7 @@ onMounted(() => {
       .user-name {
         font-size: 1rem;
         font-weight: 600;
-        color: #1f2937;
+        color: var(--text-primary);
         margin: 0 0 0.25rem;
         
         :deep(mark) {
@@ -923,13 +929,13 @@ onMounted(() => {
       }
       
       .user-role {
-        color: #6b7280;
+        color: var(--text-secondary);
         font-size: 0.875rem;
         margin: 0 0 0.25rem;
       }
       
       .user-activity {
-        color: #9ca3af;
+        color: var(--text-muted);
         font-size: 0.75rem;
         margin: 0;
       }
@@ -943,12 +949,12 @@ onMounted(() => {
     display: flex;
     align-items: center;
     padding: 1.5rem;
-    border-bottom: 1px solid #f3f4f6;
+    border-bottom: 1px solid var(--border-secondary);
     cursor: pointer;
     transition: background-color 0.2s ease;
     
     &:hover {
-      background: #f9fafb;
+      background: var(--interactive-secondary);
     }
     
     &:last-child {
@@ -956,7 +962,7 @@ onMounted(() => {
     }
     
     i {
-      color: #3b82f6;
+      color: var(--interactive-primary);
       margin-right: 1rem;
       font-size: 1.25rem;
     }
@@ -965,7 +971,7 @@ onMounted(() => {
       h3 {
         font-size: 1rem;
         font-weight: 600;
-        color: #1f2937;
+        color: var(--text-primary);
         margin: 0 0 0.25rem;
         
         :deep(mark) {
@@ -977,14 +983,14 @@ onMounted(() => {
       }
       
       p {
-        color: #6b7280;
+        color: var(--text-secondary);
         font-size: 0.875rem;
         margin: 0 0 0.25rem;
       }
       
       .tag-type, .course-credits {
-        background: #f3f4f6;
-        color: #6b7280;
+        background: var(--surface-secondary);
+        color: var(--text-secondary);
         padding: 0.125rem 0.5rem;
         border-radius: 0.375rem;
         font-size: 0.75rem;
@@ -1001,29 +1007,30 @@ onMounted(() => {
   justify-content: center;
   gap: 0.5rem;
   padding: 1.5rem;
-  border-top: 1px solid #f3f4f6;
+  border-top: 1px solid var(--border-secondary);
   
   .pagination-btn, .page-btn {
     padding: 0.5rem 0.75rem;
-    background: white;
-    border: 1px solid #d1d5db;
+    background: var(--surface-primary);
+    border: 1px solid var(--border-primary);
     border-radius: 0.375rem;
     cursor: pointer;
     transition: all 0.2s ease;
     font-size: 0.875rem;
+    color: var(--text-primary);
     
     &:hover {
-      background: #f9fafb;
-      border-color: #9ca3af;
+      background: var(--interactive-secondary);
+      border-color: var(--border-secondary);
     }
     
     &.active {
-      background: #3b82f6;
-      color: white;
-      border-color: #3b82f6;
+      background: var(--interactive-primary);
+      color: var(--text-inverse);
+      border-color: var(--interactive-primary);
       
       &:hover {
-        background: #2563eb;
+        background: var(--interactive-hover);
       }
     }
   }

--- a/pages/setting/background.vue
+++ b/pages/setting/background.vue
@@ -1,197 +1,217 @@
 <script setup lang="ts">
 import { storeToRefs } from "pinia";
 import { usePersistHomeStore } from "~/store/homeStore";
-import BackgroundSettings from "~/components/setting/BackgroundSettings.vue";
+import { useThemeStore } from "~/store/themeStore";
 
 // 获取主页状态
 const homeStore = usePersistHomeStore();
+const themeStore = useThemeStore();
+
+// 自动重定向到新的主题设置页面
+onMounted(() => {
+  // 给用户一点时间看到重定向消息
+  setTimeout(() => {
+    navigateTo('/setting/theme');
+  }, 2000);
+});
 </script>
 
 <template>
   <HomeContainer>
-    <div class="settings-container">
-      <h1 class="page-title">背景设置</h1>
-      <BackgroundSettings />
+    <div class="redirect-container">
+      <div class="redirect-content">
+        <h1 class="redirect-title">页面已升级</h1>
+        <div class="redirect-message">
+          <p class="main-message">
+            🎨 背景设置已升级为更强大的主题系统！
+          </p>
+          <p class="sub-message">
+            新的主题系统包含：
+          </p>
+          <ul class="feature-list">
+            <li>✨ 6个精美预设主题</li>
+            <li>🌙 智能深色模式</li>
+            <li>🎯 一键主题切换</li>
+            <li>📱 更好的移动端体验</li>
+          </ul>
+          <p class="redirect-note">
+            正在为您跳转到新的主题设置页面...
+          </p>
+        </div>
+        
+        <div class="redirect-actions">
+          <button 
+            class="action-btn primary-btn"
+            @click="navigateTo('/setting/theme')"
+          >
+            <span class="btn-icon">🚀</span>
+            立即体验新主题系统
+          </button>
+          
+          <button 
+            class="action-btn secondary-btn"
+            @click="navigateTo('/')"
+          >
+            <span class="btn-icon">🏠</span>
+            返回主页
+          </button>
+        </div>
+        
+        <div class="compatibility-note">
+          <p>💡 您的现有背景设置已自动迁移到新系统</p>
+        </div>
+      </div>
     </div>
   </HomeContainer>
 </template>
 
 <style lang="scss" scoped>
-.background-settings {
+.redirect-container {
+  max-width: 600px;
+  margin: 2rem auto;
   padding: 1rem;
-  background-color: rgba(193, 243, 243, 0.6); /* 降低透明度以使背景更微妙 */
-  border-radius: 8px;
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
-
+  
   @media (min-width: 768px) {
-    padding: 1.25rem;
+    margin: 3rem auto;
+    padding: 2rem;
   }
+}
 
-  h3 {
-    margin-top: 0;
-    margin-bottom: 1.5rem;
-    text-align: center;
+.redirect-content {
+  background: var(--surface-primary);
+  border-radius: 16px;
+  padding: 2rem;
+  text-align: center;
+  box-shadow: var(--shadow-large);
+  border: 1px solid var(--border-primary);
+  
+  @media (max-width: 767px) {
+    padding: 1.5rem;
+    border-radius: 12px;
+  }
+}
+
+.redirect-title {
+  margin: 0 0 1.5rem 0;
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  
+  @media (max-width: 767px) {
+    font-size: 1.75rem;
+  }
+}
+
+.redirect-message {
+  margin-bottom: 2rem;
+  
+  .main-message {
     font-size: 1.2rem;
-    color: #444;
-
-    @media (min-width: 480px) {
-      font-size: 1.25rem;
-    }
-
-    @media (min-width: 768px) {
-      font-size: 1.3rem;
-    }
+    color: var(--text-primary);
+    margin-bottom: 1rem;
+    font-weight: 500;
   }
-
-  .setting-group {
-    margin-bottom: 1.5rem;
-
-    label {
-      display: block;
-      margin-bottom: 0.75rem;
-      font-weight: 500;
+  
+  .sub-message {
+    color: var(--text-secondary);
+    margin-bottom: 1rem;
+    font-size: 1rem;
+  }
+  
+  .feature-list {
+    list-style: none;
+    padding: 0;
+    margin: 1rem 0;
+    text-align: left;
+    max-width: 300px;
+    margin-left: auto;
+    margin-right: auto;
+    
+    li {
+      padding: 0.5rem 0;
+      color: var(--text-secondary);
       font-size: 0.95rem;
-
-      @media (max-width: 479px) {
-        font-size: 1rem;
-      }
-    }
-
-    input {
-      width: 100%;
-      padding: 0.75rem;
-      border: 1px solid #ddd;
-      border-radius: 4px;
-      font-size: 1rem;
-      min-height: 44px; // Touch-friendly minimum height
-      -webkit-appearance: none; // Remove iOS styling
-
-      @media (min-width: 480px) {
-        padding: 0.5rem;
-        min-height: auto;
-      }
-
-      &:focus {
-        outline: none;
-        border-color: var(--color-blue-7, #9fc3e7);
-        box-shadow: 0 0 0 2px rgba(159, 195, 231, 0.2);
-      }
-
-      // Prevent zoom on iOS
-      @media (max-width: 479px) {
-        font-size: 16px;
-      }
     }
   }
-
-  .remove-btn,
-  .home-btn {
-    display: inline-block;
-    padding: 0.75rem 1.25rem;
-    border: none;
-    border-radius: 6px;
-    font-size: 0.95rem;
-    cursor: pointer;
-    transition: all 0.2s;
-    min-height: 44px; // Touch-friendly minimum height
-    display: flex;
-    align-items: center;
-    justify-content: center;
-
-    @media (min-width: 480px) {
-      padding: 0.6rem 1rem;
-      border-radius: 4px;
-      min-height: auto;
-      display: inline-block;
-    }
-
-    @media (max-width: 479px) {
-      font-size: 1rem;
-      flex: 1;
-    }
-  }
-
-  .remove-btn {
-    background-color: #f44336;
-    color: white;
-    margin-right: 0;
-
-    @media (min-width: 480px) {
-      margin-right: 0.75rem;
-    }
-
-    &:hover {
-      background-color: #d32f2f;
-      transform: translateY(-1px);
-    }
-
-    &:active {
-      transform: translateY(0);
-    }
-  }
-
-  .home-btn {
-    background-color: var(--color-blue-7, #9fc3e7);
-    color: white;
-
-    &:hover {
-      background-color: #7ba8d6;
-      transform: translateY(-1px);
-    }
-
-    &:active {
-      transform: translateY(0);
-    }
-  }
-
-  .button-group {
+  
+  .redirect-note {
+    color: var(--text-muted);
+    font-size: 0.9rem;
+    font-style: italic;
     margin-top: 1.5rem;
-    display: flex;
-    justify-content: center;
-    gap: 12px;
+  }
+}
 
-    @media (max-width: 479px) {
-      flex-direction: column;
-      gap: 0.75rem;
+.redirect-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+  
+  @media (min-width: 480px) {
+    flex-direction: row;
+    justify-content: center;
+  }
+}
+
+.action-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 1rem 1.5rem;
+  border: none;
+  border-radius: 8px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  font-size: 1rem;
+  text-decoration: none;
+  
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-medium);
+  }
+  
+  &:active {
+    transform: translateY(0);
+  }
+  
+  .btn-icon {
+    font-size: 1.1rem;
+  }
+  
+  &.primary-btn {
+    background: var(--interactive-primary);
+    color: var(--text-inverse);
+    
+    &:hover {
+      background: var(--interactive-hover);
+    }
+  }
+  
+  &.secondary-btn {
+    background: var(--surface-secondary);
+    color: var(--text-primary);
+    border: 2px solid var(--border-primary);
+    
+    &:hover {
+      background: var(--surface-elevated);
+      border-color: var(--interactive-primary);
     }
   }
 }
 
-.settings-container {
-  max-width: 1000px;
-  margin: 1rem auto;
+.compatibility-note {
   padding: 1rem;
+  background: var(--surface-secondary);
   border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-
-  @media (min-width: 480px) {
-    margin: 1.5rem auto;
-    padding: 1.25rem;
-  }
-
-  @media (min-width: 768px) {
-    margin: 2rem auto;
-    padding: 1.5rem;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-  }
+  border-left: 4px solid var(--semantic-info);
   
-  .page-title {
-    text-align: center;
-    margin-top: 0;
-    margin-bottom: 1.5rem;
-    font-size: 1.5rem;
-    font-weight: 600;
-    color: #333;
-    padding: 0;
-
-    @media (min-width: 480px) {
-      font-size: 1.75rem;
-    }
-
-    @media (min-width: 768px) {
-      text-align: left;
-      font-size: 2rem;
-    }
+  p {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: 0.9rem;
   }
 }
 </style>

--- a/pages/setting/theme.vue
+++ b/pages/setting/theme.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import { storeToRefs } from "pinia";
+import { usePersistHomeStore } from "~/store/homeStore";
+import ThemeSettings from "~/components/setting/ThemeSettings.vue";
+
+// 获取主页状态
+const homeStore = usePersistHomeStore();
+
+// 设置页面元数据
+definePageMeta({
+  title: '主题设置'
+});
+
+// 设置头部信息
+useHead({
+  title: '主题设置 - UniKorn Campus',
+  meta: [
+    { name: 'description', content: '自定义您的校园论坛主题外观' }
+  ]
+});
+</script>
+
+<template>
+  <HomeContainer>
+    <div class="settings-container">
+      <h1 class="page-title">主题设置</h1>
+      <ThemeSettings />
+    </div>
+  </HomeContainer>
+</template>
+
+<style lang="scss" scoped>
+.settings-container {
+  max-width: 1200px;
+  margin: 1rem auto;
+  padding: 1rem;
+  
+  @media (min-width: 768px) {
+    margin: 1.5rem auto;
+    padding: 1.5rem;
+  }
+  
+  .page-title {
+    text-align: center;
+    margin-top: 0;
+    margin-bottom: 2rem;
+    font-size: 1.75rem;
+    font-weight: 600;
+    color: var(--text-primary);
+    padding: 0;
+    
+    @media (min-width: 768px) {
+      text-align: left;
+      font-size: 2rem;
+    }
+  }
+}
+</style>

--- a/pages/users/[id].vue
+++ b/pages/users/[id].vue
@@ -524,7 +524,7 @@ useHead({
 <style lang="scss" scoped>
 .user-profile-page {
   min-height: calc(100vh - 140px);
-  background-color: #f8f9fa;
+  background-color: var(--surface-secondary);
   padding: 0.5rem;
 
   @media (min-width: 768px) {
@@ -537,9 +537,9 @@ useHead({
 }
 
 .user-profile-card {
-  background: white;
+  background: var(--card-bg);
   border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-medium);
   padding: 1rem;
   max-width: 1000px;
   margin: 0 auto;
@@ -547,7 +547,7 @@ useHead({
   @media (min-width: 480px) {
     padding: 1.5rem;
     border-radius: 12px;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+    box-shadow: var(--shadow-large);
   }
 
   @media (min-width: 768px) {
@@ -561,7 +561,7 @@ useHead({
   gap: 1rem;
   margin-bottom: 1.5rem;
   padding-bottom: 1rem;
-  border-bottom: 1px solid #e0e0e0;
+  border-bottom: 1px solid var(--border-primary);
   flex-direction: column;
   text-align: center;
 
@@ -594,10 +594,10 @@ useHead({
   align-items: center;
   gap: 0.5rem;
   padding: 0.75rem 1.25rem;
-  border: 2px solid #e0e0e0;
+  border: 2px solid var(--border-primary);
   border-radius: 25px;
-  background: white;
-  color: #666;
+  background: var(--surface-primary);
+  color: var(--text-secondary);
   font-size: 0.875rem;
   cursor: pointer;
   transition: all 0.2s ease;
@@ -612,14 +612,14 @@ useHead({
   }
 
   &:hover {
-    border-color: #3498db;
-    color: #3498db;
+    border-color: var(--interactive-primary);
+    color: var(--interactive-primary);
   }
 
   &.active {
-    background: #3498db;
-    border-color: #3498db;
-    color: white;
+    background: var(--interactive-primary);
+    border-color: var(--interactive-primary);
+    color: var(--text-inverse);
   }
 
   .icon-fallback {
@@ -635,9 +635,9 @@ useHead({
 .avatar-upload-section {
   margin: 1rem 0;
   padding: 1rem;
-  background: #f8f9fa;
+  background: var(--surface-secondary);
   border-radius: 8px;
-  border: 2px dashed #e0e0e0;
+  border: 2px dashed var(--border-secondary);
 
   @media (min-width: 480px) {
     margin: 1.5rem 0;
@@ -681,7 +681,7 @@ useHead({
     .user-name {
       font-size: 1.5rem;
       font-weight: 700;
-      color: #2c3e50;
+      color: var(--text-primary);
       margin: 0;
       word-break: break-word;
 
@@ -697,7 +697,7 @@ useHead({
     .edit-username-btn {
       background: none;
       border: none;
-      color: #666;
+      color: var(--text-secondary);
       cursor: pointer;
       padding: 0.75rem;
       border-radius: 50%;
@@ -717,8 +717,8 @@ useHead({
       }
 
       &:hover {
-        background: #f0f0f0;
-        color: #3498db;
+        background: var(--surface-secondary);
+        color: var(--interactive-primary);
         transform: scale(1.1);
       }
 
@@ -750,11 +750,11 @@ useHead({
       .username-input {
         font-size: 1.25rem;
         font-weight: 700;
-        color: #2c3e50;
-        border: 2px solid #e0e0e0;
+        color: var(--text-primary);
+        border: 2px solid var(--border-primary);
         border-radius: 8px;
         padding: 0.75rem;
-        background: white;
+        background: var(--surface-primary);
         transition: border-color 0.2s ease;
         min-width: 200px;
         flex: 1;
@@ -770,17 +770,17 @@ useHead({
 
         &:focus {
           outline: none;
-          border-color: #3498db;
-          box-shadow: 0 0 0 3px rgba(52, 152, 219, 0.1);
+          border-color: var(--border-focus);
+          box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
         }
 
         &.error {
-          border-color: #e74c3c;
+          border-color: var(--semantic-error);
         }
 
         &:disabled {
-          background: #f8f9fa;
-          color: #999;
+          background: var(--surface-secondary);
+          color: var(--text-muted);
           cursor: not-allowed;
         }
       }
@@ -835,21 +835,21 @@ useHead({
         }
 
         .save-btn {
-          background: #27ae60;
-          color: white;
+          background: var(--semantic-success);
+          color: var(--text-inverse);
 
           &:hover:not(:disabled) {
-            background: #229954;
+            background: var(--semantic-success);
             transform: scale(1.05);
           }
         }
 
         .cancel-btn {
-          background: #e74c3c;
-          color: white;
+          background: var(--semantic-error);
+          color: var(--text-inverse);
 
           &:hover:not(:disabled) {
-            background: #c0392b;
+            background: var(--semantic-error);
             transform: scale(1.05);
           }
         }
@@ -857,14 +857,14 @@ useHead({
     }
 
     .username-error {
-      color: #e74c3c;
+      color: var(--semantic-error);
       font-size: 0.875rem;
       margin-bottom: 0.25rem;
       font-weight: 500;
     }
 
     .username-help {
-      color: #666;
+      color: var(--text-secondary);
       font-size: 0.75rem;
       font-style: italic;
     }
@@ -888,13 +888,13 @@ useHead({
   font-weight: 500;
 
   &.badge-primary {
-    background-color: rgba(25, 118, 210, 0.2);
-    color: #1976d2;
+    background-color: rgba(59, 130, 246, 0.2);
+    color: var(--interactive-primary);
   }
 
   &.badge-success {
-    background-color: rgba(76, 175, 80, 0.2);
-    color: #4caf50;
+    background-color: rgba(16, 185, 129, 0.2);
+    color: var(--semantic-success);
   }
 }
 
@@ -909,12 +909,12 @@ useHead({
     .stat-value {
       font-size: 2rem;
       font-weight: 700;
-      color: #3498db;
+      color: var(--interactive-primary);
     }
 
     .stat-label {
       font-size: 0.875rem;
-      color: #666;
+      color: var(--text-secondary);
     }
   }
 }
@@ -937,7 +937,7 @@ useHead({
 }
 
 .stat-card {
-  background-color: #f8f9fa;
+  background-color: var(--surface-secondary);
   border-radius: 8px;
   padding: 1rem;
   text-align: center;
@@ -953,7 +953,7 @@ useHead({
 
   &:hover {
     transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    box-shadow: var(--shadow-medium);
   }
 
   &:active {
@@ -963,7 +963,7 @@ useHead({
   .stat-number {
     font-size: 1.25rem;
     font-weight: 700;
-    color: #2c3e50;
+    color: var(--text-primary);
     margin-bottom: 0.25rem;
 
     @media (min-width: 480px) {
@@ -977,7 +977,7 @@ useHead({
 
   .stat-text {
     font-size: 0.8rem;
-    color: #666;
+    color: var(--text-secondary);
 
     @media (min-width: 480px) {
       font-size: 0.875rem;
@@ -998,7 +998,7 @@ useHead({
   justify-content: space-between;
   align-items: flex-start;
   padding: 0.875rem 0;
-  border-bottom: 1px solid #f0f0f0;
+  border-bottom: 1px solid var(--border-secondary);
   gap: 1rem;
 
   @media (min-width: 480px) {
@@ -1012,7 +1012,7 @@ useHead({
 
   .detail-label {
     font-weight: 500;
-    color: #666;
+    color: var(--text-secondary);
     font-size: 0.9rem;
     flex-shrink: 0;
 
@@ -1023,7 +1023,7 @@ useHead({
 
   .detail-value {
     font-weight: 600;
-    color: #2c3e50;
+    color: var(--text-primary);
     text-align: right;
     word-break: break-all;
     font-size: 0.9rem;
@@ -1039,15 +1039,15 @@ useHead({
   .bio-title {
     font-size: 1.25rem;
     font-weight: 600;
-    color: #2c3e50;
+    color: var(--text-primary);
     margin-bottom: 1rem;
   }
 
   .bio-content {
-    background-color: #f8f9fa;
+    background-color: var(--surface-secondary);
     border-radius: 8px;
     padding: 1rem;
-    color: #555;
+    color: var(--text-secondary);
     line-height: 1.6;
     font-style: italic;
   }
@@ -1065,15 +1065,15 @@ useHead({
   .loading-spinner {
     width: 40px;
     height: 40px;
-    border: 4px solid #f3f3f3;
-    border-top: 4px solid #3498db;
+    border: 4px solid var(--border-secondary);
+    border-top: 4px solid var(--interactive-primary);
     border-radius: 50%;
     animation: spin 1s linear infinite;
   }
 
   p {
     font-size: 1.1rem;
-    color: #666;
+    color: var(--text-secondary);
   }
 }
 
@@ -1090,33 +1090,36 @@ useHead({
 .error {
   text-align: center;
   padding: 3rem 2rem;
-  background-color: #fdf2f2;
-  border: 1px solid #fecaca;
+  background-color: var(--surface-primary);
+  border: 1px solid var(--semantic-error);
   border-radius: 8px;
   margin: 2rem auto;
   max-width: 500px;
+  box-shadow: var(--shadow-medium);
 
   h2 {
-    color: #dc2626;
+    color: var(--semantic-error);
     margin-bottom: 1rem;
   }
 
   p {
-    color: #7f1d1d;
+    color: var(--text-secondary);
     margin-bottom: 1.5rem;
   }
 
   .retry-btn {
-    background-color: #dc2626;
-    color: white;
+    background-color: var(--semantic-error);
+    color: var(--text-inverse);
     border: none;
     padding: 0.75rem 1.5rem;
     border-radius: 6px;
     cursor: pointer;
     font-size: 1rem;
+    transition: all var(--transition-fast);
 
     &:hover {
-      background-color: #b91c1c;
+      opacity: 0.9;
+      transform: translateY(-1px);
     }
   }
 }

--- a/plugins/theme.client.ts
+++ b/plugins/theme.client.ts
@@ -3,37 +3,19 @@ import { useThemeStore } from '~/store/themeStore';
 export default defineNuxtPlugin(() => {
   const themeStore = useThemeStore();
   
-  // 在DOM加载完成后应用主题
-  function applyTheme() {
-    // 应用背景颜色
-    if (themeStore.backgroundColor) {
-      document.documentElement.style.setProperty(
-        '--background-color',
-        themeStore.backgroundColor
-      );
-    }
+  // Initialize theme system
+  function initializeTheme() {
+    // Try to migrate from legacy settings if needed
+    themeStore.migrateFromLegacySettings();
     
-    // 应用背景图片
-    if (themeStore.backgroundImage) {
-      document.documentElement.style.setProperty(
-        '--background-image',
-        `url(${themeStore.backgroundImage})`
-      );
-    } else {
-      document.documentElement.style.setProperty('--background-image', 'none');
-    }
-    
-    // 应用透明度
-    document.documentElement.style.setProperty(
-      '--background-opacity',
-      themeStore.backgroundOpacity.toString()
-    );
+    // Apply the current theme
+    themeStore.initializeTheme();
   }
   
-  // 确保在DOM准备好后应用主题
+  // Ensure theme is applied after DOM is ready
   if (document.readyState !== 'loading') {
-    applyTheme();
+    initializeTheme();
   } else {
-    document.addEventListener('DOMContentLoaded', applyTheme);
+    document.addEventListener('DOMContentLoaded', initializeTheme);
   }
 });

--- a/store/themeStore.ts
+++ b/store/themeStore.ts
@@ -1,29 +1,82 @@
 import { defineStore } from 'pinia'
-
-interface ThemeState {
-  backgroundColor: string;
-  backgroundImage: string | null;
-  backgroundOpacity: number;
-}
+import type { ThemeState, ThemeConfig } from '~/types/theme'
+import { themes, getThemeById, generateCSSVariables } from '~/utils/themes'
 
 export const useThemeStore = defineStore('theme', {
   state: (): ThemeState => ({
+    currentTheme: 'light',
+    availableThemes: themes,
+    // Legacy compatibility
     backgroundColor: '#97d4f3',
     backgroundImage: null,
-    backgroundOpacity: 0.7
+    backgroundOpacity: 0.7,
+    customTheme: undefined
   }),
   
+  getters: {
+    activeTheme(): ThemeConfig | undefined {
+      return getThemeById(this.currentTheme) || this.availableThemes[0];
+    },
+    
+    isLegacyTheme(): boolean {
+      return this.currentTheme === 'legacy' || !getThemeById(this.currentTheme);
+    },
+    
+    themeVariables(): Record<string, string> {
+      if (this.activeTheme) {
+        return generateCSSVariables(this.activeTheme);
+      }
+      
+      // Legacy fallback
+      return {
+        '--background-color': this.backgroundColor,
+        '--background-image': this.backgroundImage ? `url(${this.backgroundImage})` : 'none',
+        '--background-opacity': this.backgroundOpacity.toString()
+      };
+    }
+  },
+  
   actions: {
+    setTheme(themeId: string) {
+      const theme = getThemeById(themeId);
+      if (!theme) {
+        console.warn(`Theme "${themeId}" not found`);
+        return;
+      }
+      
+      this.currentTheme = themeId;
+      this.applyTheme(theme);
+    },
+    
+    applyTheme(theme: ThemeConfig) {
+      if (!process.client) return;
+      
+      const variables = generateCSSVariables(theme);
+      const documentElement = document.documentElement;
+      
+      // Apply all CSS variables
+      Object.entries(variables).forEach(([property, value]) => {
+        documentElement.style.setProperty(property, value);
+      });
+      
+      // Update body class for theme-specific styling
+      document.body.className = document.body.className
+        .replace(/theme-\w+/g, '')
+        .trim();
+      document.body.classList.add(`theme-${theme.id}`);
+    },
+    
+    // Legacy methods for backward compatibility
     setBackgroundColor(color: string) {
       this.backgroundColor = color;
-      if (process.client) {
+      if (this.currentTheme === 'legacy' && process.client) {
         document.documentElement.style.setProperty('--background-color', color);
       }
     },
     
     setBackgroundImage(imageUrl: string | null) {
       this.backgroundImage = imageUrl;
-      if (process.client) {
+      if (this.currentTheme === 'legacy' && process.client) {
         if (imageUrl) {
           document.documentElement.style.setProperty(
             '--background-image', 
@@ -37,15 +90,44 @@ export const useThemeStore = defineStore('theme', {
     
     setBackgroundOpacity(opacity: number) {
       this.backgroundOpacity = opacity;
-      if (process.client) {
+      if (this.currentTheme === 'legacy' && process.client) {
         document.documentElement.style.setProperty('--background-opacity', opacity.toString());
+      }
+    },
+    
+    // Initialize theme on app start
+    initializeTheme() {
+      if (!process.client) return;
+      
+      if (this.activeTheme) {
+        this.applyTheme(this.activeTheme);
+      } else {
+        // Apply legacy theme if no modern theme is set
+        this.setBackgroundColor(this.backgroundColor);
+        this.setBackgroundImage(this.backgroundImage);
+        this.setBackgroundOpacity(this.backgroundOpacity);
+      }
+    },
+    
+    // Migration helper
+    migrateFromLegacySettings() {
+      if (this.currentTheme === 'legacy' || !getThemeById(this.currentTheme)) {
+        // Try to find a matching theme based on legacy settings
+        if (this.backgroundColor === '#0f172a' || this.backgroundColor.includes('1e293b')) {
+          this.setTheme('dark');
+        } else if (this.backgroundColor.includes('#fef7ed') || this.backgroundColor.includes('fed7aa')) {
+          this.setTheme('cafe');
+        } else if (this.backgroundColor.includes('#f0f9ff') || this.backgroundColor.includes('0ea5e9')) {
+          this.setTheme('ocean');
+        } else {
+          this.setTheme('light');
+        }
       }
     }
   },
   
-  // 条件应用持久化配置
   persist: process.client ? {
     storage: localStorage,
-    paths: ['backgroundColor', 'backgroundImage', 'backgroundOpacity']
+    paths: ['currentTheme', 'backgroundColor', 'backgroundImage', 'backgroundOpacity', 'customTheme']
   } : false
 })

--- a/types/theme.ts
+++ b/types/theme.ts
@@ -1,0 +1,110 @@
+// Theme system types
+export interface ThemeConfig {
+  id: string;
+  name: string;
+  description: string;
+  category: 'light' | 'dark' | 'colored';
+  
+  // Background styling
+  background: {
+    primary: string;
+    secondary?: string;
+    image?: string;
+    gradient?: string;
+  };
+  
+  // Component colors
+  colors: {
+    // Text colors
+    text: {
+      primary: string;
+      secondary: string;
+      muted: string;
+      inverse: string;
+    };
+    
+    // Surface colors
+    surface: {
+      primary: string;
+      secondary: string;
+      elevated: string;
+      overlay: string;
+    };
+    
+    // Interactive colors
+    interactive: {
+      primary: string;
+      secondary: string;
+      hover: string;
+      active: string;
+      disabled: string;
+    };
+    
+    // Semantic colors
+    semantic: {
+      success: string;
+      warning: string;
+      error: string;
+      info: string;
+    };
+    
+    // Border colors
+    border: {
+      primary: string;
+      secondary: string;
+      focus: string;
+    };
+  };
+  
+  // Component-specific styling
+  components: {
+    sidebar: {
+      background: string;
+      backdrop?: string;
+      shadow?: string;
+    };
+    
+    topbar: {
+      background: string;
+      backdrop?: string;
+      shadow?: string;
+    };
+    
+    card: {
+      background: string;
+      shadow?: string;
+      border?: string;
+    };
+    
+    modal: {
+      background: string;
+      backdrop: string;
+      shadow?: string;
+    };
+  };
+  
+  // Effects and overlays
+  effects: {
+    blur: string;
+    shadow: {
+      small: string;
+      medium: string;
+      large: string;
+    };
+    opacity: {
+      low: number;
+      medium: number;
+      high: number;
+    };
+  };
+}
+
+export interface ThemeState {
+  currentTheme: string;
+  availableThemes: ThemeConfig[];
+  // Legacy support
+  backgroundColor?: string;
+  backgroundImage?: string | null;
+  backgroundOpacity?: number;
+  customTheme?: Partial<ThemeConfig>;
+}

--- a/utils/themes.ts
+++ b/utils/themes.ts
@@ -1,0 +1,655 @@
+import type { ThemeConfig } from '~/types/theme';
+
+// Predefined theme configurations
+export const themes: ThemeConfig[] = [
+  // Light Theme
+  {
+    id: 'light',
+    name: '简洁白',
+    description: '清新简洁的浅色主题，适合日常使用',
+    category: 'light',
+    
+    background: {
+      primary: '#ffffff',
+      secondary: '#f8fafc',
+      gradient: 'linear-gradient(135deg, #ffffff 0%, #f1f5f9 100%)'
+    },
+    
+    colors: {
+      text: {
+        primary: '#1e293b',
+        secondary: '#475569',
+        muted: '#94a3b8',
+        inverse: '#ffffff'
+      },
+      
+      surface: {
+        primary: '#ffffff',
+        secondary: '#f8fafc',
+        elevated: '#ffffff',
+        overlay: 'rgba(255, 255, 255, 0.95)'
+      },
+      
+      interactive: {
+        primary: '#3b82f6',
+        secondary: '#e2e8f0',
+        hover: '#2563eb',
+        active: '#1d4ed8',
+        disabled: '#cbd5e1'
+      },
+      
+      semantic: {
+        success: '#10b981',
+        warning: '#f59e0b',
+        error: '#ef4444',
+        info: '#3b82f6'
+      },
+      
+      border: {
+        primary: '#e2e8f0',
+        secondary: '#f1f5f9',
+        focus: '#3b82f6'
+      }
+    },
+    
+    components: {
+      sidebar: {
+        background: 'rgba(255, 255, 255, 0.95)',
+        backdrop: 'blur(12px)',
+        shadow: '0 4px 24px rgba(0, 0, 0, 0.06)'
+      },
+      
+      topbar: {
+        background: 'rgba(255, 255, 255, 0.95)',
+        backdrop: 'blur(12px)',
+        shadow: '0 1px 3px rgba(0, 0, 0, 0.05)'
+      },
+      
+      card: {
+        background: '#ffffff',
+        shadow: '0 1px 3px rgba(0, 0, 0, 0.05)',
+        border: '1px solid #e2e8f0'
+      },
+      
+      modal: {
+        background: '#ffffff',
+        backdrop: 'rgba(0, 0, 0, 0.5)',
+        shadow: '0 20px 25px -5px rgba(0, 0, 0, 0.1)'
+      }
+    },
+    
+    effects: {
+      blur: 'blur(12px)',
+      shadow: {
+        small: '0 1px 2px rgba(0, 0, 0, 0.05)',
+        medium: '0 4px 6px rgba(0, 0, 0, 0.07)',
+        large: '0 10px 15px rgba(0, 0, 0, 0.1)'
+      },
+      opacity: {
+        low: 0.6,
+        medium: 0.8,
+        high: 0.95
+      }
+    }
+  },
+
+  // Dark Theme
+  {
+    id: 'dark',
+    name: '深夜黑',
+    description: '优雅的深色主题，减少眼部疲劳',
+    category: 'dark',
+    
+    background: {
+      primary: '#0f172a',
+      secondary: '#1e293b',
+      gradient: 'linear-gradient(135deg, #0f172a 0%, #1e293b 100%)'
+    },
+    
+    colors: {
+      text: {
+        primary: '#f8fafc',
+        secondary: '#cbd5e1',
+        muted: '#64748b',
+        inverse: '#0f172a'
+      },
+      
+      surface: {
+        primary: '#1e293b',
+        secondary: '#334155',
+        elevated: '#2d3748',
+        overlay: 'rgba(30, 41, 59, 0.95)'
+      },
+      
+      interactive: {
+        primary: '#60a5fa',
+        secondary: '#374151',
+        hover: '#3b82f6',
+        active: '#2563eb',
+        disabled: '#4b5563'
+      },
+      
+      semantic: {
+        success: '#34d399',
+        warning: '#fbbf24',
+        error: '#f87171',
+        info: '#60a5fa'
+      },
+      
+      border: {
+        primary: '#374151',
+        secondary: '#4b5563',
+        focus: '#60a5fa'
+      }
+    },
+    
+    components: {
+      sidebar: {
+        background: 'rgba(30, 41, 59, 0.95)',
+        backdrop: 'blur(12px)',
+        shadow: '0 4px 24px rgba(0, 0, 0, 0.2)'
+      },
+      
+      topbar: {
+        background: 'rgba(30, 41, 59, 0.95)',
+        backdrop: 'blur(12px)',
+        shadow: '0 1px 3px rgba(0, 0, 0, 0.3)'
+      },
+      
+      card: {
+        background: '#1e293b',
+        shadow: '0 1px 3px rgba(0, 0, 0, 0.2)',
+        border: '1px solid #374151'
+      },
+      
+      modal: {
+        background: '#1e293b',
+        backdrop: 'rgba(0, 0, 0, 0.7)',
+        shadow: '0 20px 25px -5px rgba(0, 0, 0, 0.3)'
+      }
+    },
+    
+    effects: {
+      blur: 'blur(12px)',
+      shadow: {
+        small: '0 1px 2px rgba(0, 0, 0, 0.2)',
+        medium: '0 4px 6px rgba(0, 0, 0, 0.3)',
+        large: '0 10px 15px rgba(0, 0, 0, 0.4)'
+      },
+      opacity: {
+        low: 0.6,
+        medium: 0.8,
+        high: 0.95
+      }
+    }
+  },
+
+  // Cafe Theme
+  {
+    id: 'cafe',
+    name: '温暖咖啡',
+    description: '温馨的咖啡色调，营造舒适氛围',
+    category: 'colored',
+    
+    background: {
+      primary: '#fef7ed',
+      secondary: '#fed7aa',
+      gradient: 'linear-gradient(135deg, #fef7ed 0%, #fdba74 50%, #d97706 100%)',
+      image: 'radial-gradient(circle at 20% 80%, rgba(251, 191, 36, 0.1) 0%, transparent 50%)'
+    },
+    
+    colors: {
+      text: {
+        primary: '#451a03',
+        secondary: '#7c2d12',
+        muted: '#92400e',
+        inverse: '#fef7ed'
+      },
+      
+      surface: {
+        primary: 'rgba(254, 247, 237, 0.9)',
+        secondary: 'rgba(254, 215, 170, 0.7)',
+        elevated: 'rgba(255, 255, 255, 0.9)',
+        overlay: 'rgba(254, 247, 237, 0.95)'
+      },
+      
+      interactive: {
+        primary: '#d97706',
+        secondary: '#fed7aa',
+        hover: '#b45309',
+        active: '#92400e',
+        disabled: '#d6d3d1'
+      },
+      
+      semantic: {
+        success: '#16a34a',
+        warning: '#eab308',
+        error: '#dc2626',
+        info: '#d97706'
+      },
+      
+      border: {
+        primary: '#fed7aa',
+        secondary: '#fde68a',
+        focus: '#d97706'
+      }
+    },
+    
+    components: {
+      sidebar: {
+        background: 'rgba(254, 247, 237, 0.95)',
+        backdrop: 'blur(12px)',
+        shadow: '0 4px 24px rgba(217, 119, 6, 0.1)'
+      },
+      
+      topbar: {
+        background: 'rgba(254, 247, 237, 0.95)',
+        backdrop: 'blur(12px)',
+        shadow: '0 1px 3px rgba(217, 119, 6, 0.1)'
+      },
+      
+      card: {
+        background: 'rgba(255, 255, 255, 0.8)',
+        shadow: '0 1px 3px rgba(217, 119, 6, 0.1)',
+        border: '1px solid rgba(254, 215, 170, 0.5)'
+      },
+      
+      modal: {
+        background: 'rgba(254, 247, 237, 0.98)',
+        backdrop: 'rgba(69, 26, 3, 0.4)',
+        shadow: '0 20px 25px -5px rgba(217, 119, 6, 0.2)'
+      }
+    },
+    
+    effects: {
+      blur: 'blur(12px)',
+      shadow: {
+        small: '0 1px 2px rgba(217, 119, 6, 0.1)',
+        medium: '0 4px 6px rgba(217, 119, 6, 0.15)',
+        large: '0 10px 15px rgba(217, 119, 6, 0.2)'
+      },
+      opacity: {
+        low: 0.7,
+        medium: 0.85,
+        high: 0.95
+      }
+    }
+  },
+
+  // Pro-Tech Theme
+  {
+    id: 'pro-tech',
+    name: '科技蓝',
+    description: '现代科技感主题，专业高端',
+    category: 'dark',
+    
+    background: {
+      primary: '#0a0f1c',
+      secondary: '#1a1f2e',
+      gradient: 'linear-gradient(135deg, #0a0f1c 0%, #1a1f2e 50%, #2563eb 100%)',
+      image: 'radial-gradient(circle at 80% 20%, rgba(37, 99, 235, 0.15) 0%, transparent 50%)'
+    },
+    
+    colors: {
+      text: {
+        primary: '#e2e8f0',
+        secondary: '#94a3b8',
+        muted: '#64748b',
+        inverse: '#0a0f1c'
+      },
+      
+      surface: {
+        primary: 'rgba(26, 31, 46, 0.9)',
+        secondary: 'rgba(30, 41, 59, 0.8)',
+        elevated: 'rgba(51, 65, 85, 0.9)',
+        overlay: 'rgba(26, 31, 46, 0.95)'
+      },
+      
+      interactive: {
+        primary: '#3b82f6',
+        secondary: '#1e293b',
+        hover: '#60a5fa',
+        active: '#2563eb',
+        disabled: '#334155'
+      },
+      
+      semantic: {
+        success: '#06d6a0',
+        warning: '#ffd23f',
+        error: '#f72585',
+        info: '#3b82f6'
+      },
+      
+      border: {
+        primary: 'rgba(59, 130, 246, 0.3)',
+        secondary: 'rgba(148, 163, 184, 0.2)',
+        focus: '#3b82f6'
+      }
+    },
+    
+    components: {
+      sidebar: {
+        background: 'rgba(26, 31, 46, 0.95)',
+        backdrop: 'blur(16px)',
+        shadow: '0 4px 24px rgba(59, 130, 246, 0.1)'
+      },
+      
+      topbar: {
+        background: 'rgba(26, 31, 46, 0.95)',
+        backdrop: 'blur(16px)',
+        shadow: '0 1px 3px rgba(59, 130, 246, 0.2)'
+      },
+      
+      card: {
+        background: 'rgba(30, 41, 59, 0.8)',
+        shadow: '0 1px 3px rgba(59, 130, 246, 0.1)',
+        border: '1px solid rgba(59, 130, 246, 0.2)'
+      },
+      
+      modal: {
+        background: 'rgba(26, 31, 46, 0.98)',
+        backdrop: 'rgba(10, 15, 28, 0.8)',
+        shadow: '0 20px 25px -5px rgba(59, 130, 246, 0.2)'
+      }
+    },
+    
+    effects: {
+      blur: 'blur(16px)',
+      shadow: {
+        small: '0 1px 2px rgba(59, 130, 246, 0.1)',
+        medium: '0 4px 6px rgba(59, 130, 246, 0.15)',
+        large: '0 10px 15px rgba(59, 130, 246, 0.2)'
+      },
+      opacity: {
+        low: 0.6,
+        medium: 0.8,
+        high: 0.95
+      }
+    }
+  },
+
+  // Ocean Theme
+  {
+    id: 'ocean',
+    name: '海洋蓝',
+    description: '清新海洋色调，宁静舒适',
+    category: 'colored',
+    
+    background: {
+      primary: '#f0f9ff',
+      secondary: '#e0f2fe',
+      gradient: 'linear-gradient(135deg, #f0f9ff 0%, #7dd3fc 50%, #0ea5e9 100%)',
+      image: 'radial-gradient(circle at 60% 30%, rgba(14, 165, 233, 0.1) 0%, transparent 60%)'
+    },
+    
+    colors: {
+      text: {
+        primary: '#0c4a6e',
+        secondary: '#075985',
+        muted: '#0891b2',
+        inverse: '#f0f9ff'
+      },
+      
+      surface: {
+        primary: 'rgba(240, 249, 255, 0.9)',
+        secondary: 'rgba(224, 242, 254, 0.8)',
+        elevated: 'rgba(255, 255, 255, 0.9)',
+        overlay: 'rgba(240, 249, 255, 0.95)'
+      },
+      
+      interactive: {
+        primary: '#0ea5e9',
+        secondary: '#e0f2fe',
+        hover: '#0284c7',
+        active: '#0369a1',
+        disabled: '#cbd5e1'
+      },
+      
+      semantic: {
+        success: '#059669',
+        warning: '#d97706',
+        error: '#dc2626',
+        info: '#0ea5e9'
+      },
+      
+      border: {
+        primary: '#7dd3fc',
+        secondary: '#bae6fd',
+        focus: '#0ea5e9'
+      }
+    },
+    
+    components: {
+      sidebar: {
+        background: 'rgba(240, 249, 255, 0.95)',
+        backdrop: 'blur(12px)',
+        shadow: '0 4px 24px rgba(14, 165, 233, 0.1)'
+      },
+      
+      topbar: {
+        background: 'rgba(240, 249, 255, 0.95)',
+        backdrop: 'blur(12px)',
+        shadow: '0 1px 3px rgba(14, 165, 233, 0.1)'
+      },
+      
+      card: {
+        background: 'rgba(255, 255, 255, 0.8)',
+        shadow: '0 1px 3px rgba(14, 165, 233, 0.1)',
+        border: '1px solid rgba(125, 211, 252, 0.5)'
+      },
+      
+      modal: {
+        background: 'rgba(240, 249, 255, 0.98)',
+        backdrop: 'rgba(12, 74, 110, 0.4)',
+        shadow: '0 20px 25px -5px rgba(14, 165, 233, 0.2)'
+      }
+    },
+    
+    effects: {
+      blur: 'blur(12px)',
+      shadow: {
+        small: '0 1px 2px rgba(14, 165, 233, 0.1)',
+        medium: '0 4px 6px rgba(14, 165, 233, 0.15)',
+        large: '0 10px 15px rgba(14, 165, 233, 0.2)'
+      },
+      opacity: {
+        low: 0.7,
+        medium: 0.85,
+        high: 0.95
+      }
+    }
+  },
+
+  // Sunset Theme
+  {
+    id: 'sunset',
+    name: '夕阳红',
+    description: '温暖夕阳色彩，浪漫优雅',
+    category: 'colored',
+    
+    background: {
+      primary: '#fef2f2',
+      secondary: '#fecaca',
+      gradient: 'linear-gradient(135deg, #fef2f2 0%, #fca5a5 30%, #f87171 70%, #dc2626 100%)',
+      image: 'radial-gradient(circle at 70% 20%, rgba(248, 113, 113, 0.15) 0%, transparent 50%)'
+    },
+    
+    colors: {
+      text: {
+        primary: '#7f1d1d',
+        secondary: '#991b1b',
+        muted: '#dc2626',
+        inverse: '#fef2f2'
+      },
+      
+      surface: {
+        primary: 'rgba(254, 242, 242, 0.9)',
+        secondary: 'rgba(254, 202, 202, 0.8)',
+        elevated: 'rgba(255, 255, 255, 0.9)',
+        overlay: 'rgba(254, 242, 242, 0.95)'
+      },
+      
+      interactive: {
+        primary: '#dc2626',
+        secondary: '#fecaca',
+        hover: '#b91c1c',
+        active: '#991b1b',
+        disabled: '#d1d5db'
+      },
+      
+      semantic: {
+        success: '#16a34a',
+        warning: '#d97706',
+        error: '#dc2626',
+        info: '#3b82f6'
+      },
+      
+      border: {
+        primary: '#fca5a5',
+        secondary: '#fecaca',
+        focus: '#dc2626'
+      }
+    },
+    
+    components: {
+      sidebar: {
+        background: 'rgba(254, 242, 242, 0.95)',
+        backdrop: 'blur(12px)',
+        shadow: '0 4px 24px rgba(220, 38, 38, 0.1)'
+      },
+      
+      topbar: {
+        background: 'rgba(254, 242, 242, 0.95)',
+        backdrop: 'blur(12px)',
+        shadow: '0 1px 3px rgba(220, 38, 38, 0.1)'
+      },
+      
+      card: {
+        background: 'rgba(255, 255, 255, 0.8)',
+        shadow: '0 1px 3px rgba(220, 38, 38, 0.1)',
+        border: '1px solid rgba(252, 165, 165, 0.5)'
+      },
+      
+      modal: {
+        background: 'rgba(254, 242, 242, 0.98)',
+        backdrop: 'rgba(127, 29, 29, 0.4)',
+        shadow: '0 20px 25px -5px rgba(220, 38, 38, 0.2)'
+      }
+    },
+    
+    effects: {
+      blur: 'blur(12px)',
+      shadow: {
+        small: '0 1px 2px rgba(220, 38, 38, 0.1)',
+        medium: '0 4px 6px rgba(220, 38, 38, 0.15)',
+        large: '0 10px 15px rgba(220, 38, 38, 0.2)'
+      },
+      opacity: {
+        low: 0.7,
+        medium: 0.85,
+        high: 0.95
+      }
+    }
+  }
+];
+
+// Helper functions
+export function getThemeById(id: string): ThemeConfig | undefined {
+  return themes.find(theme => theme.id === id);
+}
+
+export function getThemesByCategory(category: 'light' | 'dark' | 'colored'): ThemeConfig[] {
+  return themes.filter(theme => theme.category === category);
+}
+
+// CSS Variable generation
+export function generateCSSVariables(theme: ThemeConfig): Record<string, string> {
+  const variables: Record<string, string> = {};
+  
+  // Background variables
+  variables['--bg-primary'] = theme.background.primary;
+  if (theme.background.secondary) {
+    variables['--bg-secondary'] = theme.background.secondary;
+  }
+  if (theme.background.gradient) {
+    variables['--bg-gradient'] = theme.background.gradient;
+  }
+  if (theme.background.image) {
+    variables['--bg-image'] = theme.background.image;
+  }
+  
+  // Text color variables
+  variables['--text-primary'] = theme.colors.text.primary;
+  variables['--text-secondary'] = theme.colors.text.secondary;
+  variables['--text-muted'] = theme.colors.text.muted;
+  variables['--text-inverse'] = theme.colors.text.inverse;
+  
+  // Surface color variables
+  variables['--surface-primary'] = theme.colors.surface.primary;
+  variables['--surface-secondary'] = theme.colors.surface.secondary;
+  variables['--surface-elevated'] = theme.colors.surface.elevated;
+  variables['--surface-overlay'] = theme.colors.surface.overlay;
+  
+  // Interactive color variables
+  variables['--interactive-primary'] = theme.colors.interactive.primary;
+  variables['--interactive-secondary'] = theme.colors.interactive.secondary;
+  variables['--interactive-hover'] = theme.colors.interactive.hover;
+  variables['--interactive-active'] = theme.colors.interactive.active;
+  variables['--interactive-disabled'] = theme.colors.interactive.disabled;
+  
+  // Semantic color variables
+  variables['--semantic-success'] = theme.colors.semantic.success;
+  variables['--semantic-warning'] = theme.colors.semantic.warning;
+  variables['--semantic-error'] = theme.colors.semantic.error;
+  variables['--semantic-info'] = theme.colors.semantic.info;
+  
+  // Border color variables
+  variables['--border-primary'] = theme.colors.border.primary;
+  variables['--border-secondary'] = theme.colors.border.secondary;
+  variables['--border-focus'] = theme.colors.border.focus;
+  
+  // Component-specific variables
+  variables['--sidebar-bg'] = theme.components.sidebar.background;
+  variables['--topbar-bg'] = theme.components.topbar.background;
+  variables['--card-bg'] = theme.components.card.background;
+  variables['--modal-bg'] = theme.components.modal.background;
+  variables['--modal-backdrop'] = theme.components.modal.backdrop;
+  
+  if (theme.components.sidebar.backdrop) {
+    variables['--sidebar-backdrop'] = theme.components.sidebar.backdrop;
+  }
+  if (theme.components.topbar.backdrop) {
+    variables['--topbar-backdrop'] = theme.components.topbar.backdrop;
+  }
+  if (theme.components.sidebar.shadow) {
+    variables['--sidebar-shadow'] = theme.components.sidebar.shadow;
+  }
+  if (theme.components.topbar.shadow) {
+    variables['--topbar-shadow'] = theme.components.topbar.shadow;
+  }
+  if (theme.components.card.shadow) {
+    variables['--card-shadow'] = theme.components.card.shadow;
+  }
+  if (theme.components.card.border) {
+    variables['--card-border'] = theme.components.card.border;
+  }
+  if (theme.components.modal.shadow) {
+    variables['--modal-shadow'] = theme.components.modal.shadow;
+  }
+  
+  // Effect variables
+  variables['--effect-blur'] = theme.effects.blur;
+  variables['--shadow-small'] = theme.effects.shadow.small;
+  variables['--shadow-medium'] = theme.effects.shadow.medium;
+  variables['--shadow-large'] = theme.effects.shadow.large;
+  variables['--opacity-low'] = theme.effects.opacity.low.toString();
+  variables['--opacity-medium'] = theme.effects.opacity.medium.toString();
+  variables['--opacity-high'] = theme.effects.opacity.high.toString();
+  
+  // Legacy compatibility
+  variables['--background-color'] = theme.background.primary;
+  variables['--background-image'] = theme.background.image || 'none';
+  variables['--background-opacity'] = theme.effects.opacity.medium.toString();
+  
+  return variables;
+}


### PR DESCRIPTION
## Major Changes
- Replace background customization with 6 predefined themes (Light, Dark, Cafe, Pro-Tech, Ocean, Sunset)
- Implement CSS custom properties system for theme-aware styling
- Create TypeScript interfaces for type safety
- Add Pinia store for theme state management
- Build theme selection UI component

## Theme System Architecture
- `/types/theme.ts`: TypeScript interfaces and theme definitions
- `/utils/themes.ts`: 6 complete theme configurations with CSS variables
- `/store/themeStore.ts`: Pinia store with persistence and migration logic
- `/components/setting/ThemeSettings.vue`: Modern theme selection interface
- `/plugins/theme.client.ts`: Theme initialization and application

## Updated Components
- All layout components: HomeContainer, Sidebar, Pinned
- All page components: index, forum, courses, profile, search, settings
- All UI components: modals, forms, cards, dropdowns
- Systematic replacement of hardcoded colors with theme variables

## Critical CSS Variable Rules
✅ USE: var(--text-primary) for readable text
✅ USE: var(--surface-primary) for backgrounds
✅ USE: var(--interactive-primary) for buttons
❌ AVOID: var(--text-inverse) for regular text (poor contrast) ❌ AVOID: Hardcoded colors (#ffffff, #000000, etc.)

## Documentation
- `THEME_SYSTEM.md`: Comprehensive development guidelines
- Updated `CLAUDE.md`: Quick reference and critical rules
- Complete variable reference and usage patterns
- Testing guidelines for theme compatibility

## Text Contrast Fixes
- Fixed "发布帖子" button visibility with semi-transparent styling
- Enhanced "相关链接" card contrast with proper opacity levels
- Corrected text color logic (--text-primary vs --text-inverse)
- Ensured readability across all theme combinations

## Backward Compatibility
- Legacy theme settings automatically migrated
- Existing components gracefully degraded with fallbacks
- Theme persistence maintained in localStorage

🤖 Generated with [Claude Code](https://claude.ai/code)