### PR TITLE
[codex] campus admin console

### DIFF
--- a/composables/useAdminConsole.ts
+++ b/composables/useAdminConsole.ts
@@ -1,8 +1,16 @@
 import type {
   AdminAuditLog,
   AdminCommentsResponse,
+  AdminContestSummary,
   AdminContentSummary,
+  AdminCoursesSummary,
+  AdminFilesResponse,
+  AdminGuguMessagesResponse,
+  AdminMatchingSummary,
   AdminOverviewResponse,
+  AdminOverviewQuery,
+  AdminOverviewTrendsPayload,
+  AdminOperationsSummary,
   AdminPostsResponse,
   AdminQuery,
   AdminUsersResponse,
@@ -42,8 +50,14 @@ export function useAdminConsole() {
     return data as T;
   }
 
-  const getOverview = () => request<AdminOverviewResponse>(
-    "/api/admin/overview",
+  const getOverview = (query: AdminOverviewQuery = {}) => request<AdminOverviewResponse>(
+    `/api/admin/overview${buildQuery(query)}`,
+    {},
+    t("adminConsole.errors.loadOverview")
+  );
+
+  const getOverviewTrends = (query: AdminOverviewQuery = {}) => request<AdminOverviewTrendsPayload>(
+    `/api/admin/overview/trends${buildQuery(query)}`,
     {},
     t("adminConsole.errors.loadOverview")
   );
@@ -84,6 +98,30 @@ export function useAdminConsole() {
     t("adminConsole.errors.loadContent")
   );
 
+  const getCoursesSummary = () => request<AdminCoursesSummary>(
+    "/api/admin/courses/summary",
+    {},
+    t("adminConsole.errors.loadDomains")
+  );
+
+  const getMatchingSummary = () => request<AdminMatchingSummary>(
+    "/api/admin/matching/summary",
+    {},
+    t("adminConsole.errors.loadDomains")
+  );
+
+  const getContestSummary = () => request<AdminContestSummary>(
+    "/api/admin/contest/summary",
+    {},
+    t("adminConsole.errors.loadDomains")
+  );
+
+  const getOperationsSummary = () => request<AdminOperationsSummary>(
+    "/api/admin/operations/summary",
+    {},
+    t("adminConsole.errors.loadDomains")
+  );
+
   const getPosts = (query: AdminQuery = {}) => request<AdminPostsResponse>(
     `/api/admin/content/posts${buildQuery(query)}`,
     {},
@@ -92,6 +130,18 @@ export function useAdminConsole() {
 
   const getComments = (query: AdminQuery = {}) => request<AdminCommentsResponse>(
     `/api/admin/content/comments${buildQuery(query)}`,
+    {},
+    t("adminConsole.errors.loadContent")
+  );
+
+  const getFiles = (query: AdminQuery = {}) => request<AdminFilesResponse>(
+    `/api/admin/content/files${buildQuery(query)}`,
+    {},
+    t("adminConsole.errors.loadContent")
+  );
+
+  const getGuguMessages = (query: AdminQuery = {}) => request<AdminGuguMessagesResponse>(
+    `/api/admin/content/gugu${buildQuery(query)}`,
     {},
     t("adminConsole.errors.loadContent")
   );
@@ -108,17 +158,38 @@ export function useAdminConsole() {
     t("adminConsole.errors.updateContent")
   );
 
+  const setFileDeleted = (fileId: number, deleted: boolean, note = "") => request<{ file: unknown }>(
+    `/api/admin/content/files/${fileId}/${deleted ? "delete" : "restore"}`,
+    { method: "POST", body: { note } as any },
+    t("adminConsole.errors.updateContent")
+  );
+
+  const setGuguDeleted = (messageId: number, deleted: boolean, note = "") => request<{ gugu: unknown }>(
+    `/api/admin/content/gugu/${messageId}/${deleted ? "delete" : "restore"}`,
+    { method: "POST", body: { note } as any },
+    t("adminConsole.errors.updateContent")
+  );
+
   return {
     getOverview,
+    getOverviewTrends,
     getAuditLogs,
     getUsers,
     updateUserRole,
     setUserDeleted,
     getContentSummary,
+    getCoursesSummary,
+    getMatchingSummary,
+    getContestSummary,
+    getOperationsSummary,
     getPosts,
     getComments,
+    getFiles,
+    getGuguMessages,
     setPostDeleted,
     setCommentDeleted,
+    setFileDeleted,
+    setGuguDeleted,
   };
 }
 

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -84,21 +84,21 @@
     }
   },
   "adminShell": {
-    "title": "Site Administration",
-    "description": "Manage feedback reviews, identity verification, and future moderation tools from one shared admin surface.",
+    "title": "Campus Forum Administration",
+    "description": "Keep users, content, course collaboration, and operational health in one clear campus admin surface.",
     "nav": {
       "overview": "Overview",
       "users": "Users",
       "content": "Content",
       "feedback": "Feedback review",
       "identity": "Identity",
-      "domains": "Data and ops",
+      "domains": "Courses and ops",
       "audit": "Audit logs"
     }
   },
   "adminOverview": {
-    "title": "Admin overview",
-    "description": "Track the moderation queues that need attention and jump into each admin workspace.",
+    "title": "Campus forum overview",
+    "description": "Track campus community queues, recent growth, and course-collaboration health so admins can see what needs attention first.",
     "actions": {
       "refresh": "Refresh",
       "refreshing": "Refreshing..."
@@ -115,14 +115,17 @@
       "commentsTotal": "Comments",
       "coursesTotal": "Courses",
       "projectsTotal": "Projects",
-      "auditRecent": "Recent logs"
+      "auditRecent": "Recent logs",
+      "guguMessages": "Gugu messages",
+      "filesTotal": "Files",
+      "validTokens": "Valid STS"
     },
     "status": {
       "loadFailed": "Some admin counts could not be loaded.",
       "moduleError": "Count unavailable"
     },
-    "modulesTitle": "Admin modules",
-    "healthTitle": "Domain health",
+    "modulesTitle": "Admin workspaces",
+    "healthTitle": "Course and ops health",
     "activityTitle": "Recent admin activity",
     "activityEmpty": "No admin actions recorded yet",
     "cards": {
@@ -133,7 +136,7 @@
       },
       "content": {
         "title": "Content moderation",
-        "description": "Inspect posts, comments, uploaded files, tags, and wall activity from a single content surface.",
+        "description": "Inspect forum posts, comments, uploads, tags, and gugu wall activity to keep campus discussion readable.",
         "action": "Open content"
       },
       "feedback": {
@@ -147,15 +150,45 @@
         "action": "Open identity review"
       },
       "domains": {
-        "title": "Course, data, and operations",
-        "description": "Monitor courses, scheduler data, Academic Map, matching, contests, storage, OAuth, and notifications.",
-        "action": "Open data and ops"
+        "title": "Course and ops health",
+        "description": "Monitor courses, scheduling, team matching, contest submissions, files, notifications, and operational infrastructure.",
+        "action": "Open health panel"
       },
       "audit": {
         "title": "Audit logs",
         "description": "Trace admin mutations with actor, action, target, note, and timestamp.",
         "action": "Open audit logs"
       }
+    },
+    "trends": {
+      "title": "Growth trends",
+      "description": "Review daily additions across core campus forum activity for the last {days} days.",
+      "daySwitcher": "Trend range",
+      "days": "{days} days",
+      "incrementLabel": "Added in {days} days",
+      "emptyTitle": "No trend data",
+      "emptyDescription": "No new records are available for the selected range yet.",
+      "loadPartial": "Trend data is temporarily unavailable; the rest of the overview is still usable.",
+      "pointTitle": "{label} on {date}: {count}",
+      "metrics": {
+        "users": "Users",
+        "posts": "Posts",
+        "comments": "Comments",
+        "files": "Files",
+        "gugu": "Gugu"
+      }
+    },
+    "healthRows": {
+      "courses": "Courses and scheduler",
+      "courseCaption": "Offering and section data",
+      "academicMap": "Degree progress",
+      "academicCaption": "Records needing review",
+      "matching": "Team matching",
+      "matchingCaption": "Active projects",
+      "contest": "Activities and contests",
+      "contestCaption": "Submission records",
+      "operations": "Operations",
+      "operationsCaption": "Available STS tokens"
     }
   },
   "adminConsole": {
@@ -166,7 +199,8 @@
       "loadUsers": "Failed to load users.",
       "updateUser": "Failed to update user.",
       "loadContent": "Failed to load content.",
-      "updateContent": "Failed to update content."
+      "updateContent": "Failed to update content.",
+      "loadDomains": "Failed to load course and operations data."
     }
   },
   "adminUsers": {
@@ -234,7 +268,7 @@
   },
   "adminContent": {
     "title": "Content Management",
-    "description": "Moderate forum posts and comments while monitoring tags, files, and gugu activity.",
+    "description": "Moderate forum posts, comments, Gugu messages, and uploaded files. High-risk actions use soft deletion and audit logs.",
     "metrics": {
       "posts": "Posts",
       "comments": "Comments",
@@ -243,7 +277,9 @@
     },
     "tabs": {
       "posts": "Posts",
-      "comments": "Comments"
+      "comments": "Comments",
+      "gugu": "Gugu",
+      "files": "Files"
     },
     "filters": {
       "search": "Search",
@@ -264,19 +300,31 @@
       "deletePost": "Post soft-deleted in admin console",
       "restorePost": "Post restored in admin console",
       "deleteComment": "Comment soft-deleted in admin console",
-      "restoreComment": "Comment restored in admin console"
+      "restoreComment": "Comment restored in admin console",
+      "deleteGugu": "Gugu message soft-deleted in admin console",
+      "restoreGugu": "Gugu message restored in admin console",
+      "deleteFile": "File soft-deleted in admin console",
+      "restoreFile": "File restored in admin console"
     },
     "confirm": {
       "deletePost": "Soft-delete this post?",
       "restorePost": "Restore this post?",
       "deleteComment": "Soft-delete this comment?",
-      "restoreComment": "Restore this comment?"
+      "restoreComment": "Restore this comment?",
+      "deleteGugu": "Soft-delete this Gugu message?",
+      "restoreGugu": "Restore this Gugu message?",
+      "deleteFile": "Soft-delete this file?",
+      "restoreFile": "Restore this file?"
     },
     "messages": {
       "postDeleted": "Post deleted.",
       "postRestored": "Post restored.",
       "commentDeleted": "Comment deleted.",
-      "commentRestored": "Comment restored."
+      "commentRestored": "Comment restored.",
+      "guguDeleted": "Gugu message deleted.",
+      "guguRestored": "Gugu message restored.",
+      "fileDeleted": "File deleted.",
+      "fileRestored": "File restored."
     },
     "errors": {
       "title": "Load failed"
@@ -298,11 +346,18 @@
       "comments": "{count} comments",
       "reactions": "{count} reactions",
       "views": "{count} views"
+    },
+    "guguStats": {
+      "replyTo": "Reply to #{id}"
+    },
+    "fileStats": {
+      "size": "{size} bytes",
+      "unknownMime": "Unknown type"
     }
   },
   "adminDomains": {
-    "title": "Data And Operations",
-    "description": "Monitor course data, Academic Map, matching, contests, storage, OAuth, notifications, and push infrastructure.",
+    "title": "Courses And Operations",
+    "description": "Monitor courses, scheduler data, matching, contests, storage, OAuth, notifications, and push infrastructure.",
     "metrics": {
       "courses": "Courses",
       "offerings": "Offerings",
@@ -319,16 +374,16 @@
     "sections": {
       "courses": "Courses and scheduler",
       "academicMap": "Academic Map",
-      "matching": "Matching",
-      "contest": "Contest",
-      "operations": "Operations"
+      "matching": "Team collaboration",
+      "contest": "Campus contests",
+      "operations": "Operational infrastructure"
     },
     "descriptions": {
       "courses": "Catalog, offerings, sections, and meeting data health.",
       "academicMap": "Aggregate curriculum and user record health without exposing private grades.",
-      "matching": "Project and profile health for the team matching subsystem.",
-      "contest": "Contest configuration, organizer, and submission counts.",
-      "operations": "Storage, STS, OAuth, notification, and push infrastructure."
+      "matching": "Project and profile health for course projects and campus collaboration.",
+      "contest": "Campus contest configuration, organizer, and submission counts.",
+      "operations": "File storage, STS, OAuth, notification, and push infrastructure."
     },
     "labels": {
       "activeCourses": "Active courses",

--- a/i18n/locales/zh.json
+++ b/i18n/locales/zh.json
@@ -84,21 +84,21 @@
     }
   },
   "adminShell": {
-    "title": "站点管理后台",
-    "description": "统一处理反馈审核、身份认证和后续站务工具，先把入口和导航搭稳，后面的反馈审核页就能直接接进来。",
+    "title": "校园论坛管理后台",
+    "description": "统一照看用户、内容、课程协作和运营健康，让校园社区的日常维护有一个清楚入口。",
     "nav": {
       "overview": "概览",
       "users": "用户",
       "content": "内容",
       "feedback": "反馈审核",
       "identity": "身份认证",
-      "domains": "数据与运维",
+      "domains": "课程与运维",
       "audit": "审计日志"
     }
   },
   "adminOverview": {
-    "title": "管理概览",
-    "description": "汇总当前需要处理的后台队列，并快速进入对应管理工作台。",
+    "title": "校园论坛运营概览",
+    "description": "汇总校园社区的待处理队列、近段增量和课程协作健康度，方便管理员快速判断今天该先看哪里。",
     "actions": {
       "refresh": "刷新数据",
       "refreshing": "刷新中..."
@@ -115,14 +115,17 @@
       "commentsTotal": "评论",
       "coursesTotal": "课程",
       "projectsTotal": "项目",
-      "auditRecent": "近期日志"
+      "auditRecent": "近期日志",
+      "guguMessages": "咕咕消息",
+      "filesTotal": "文件",
+      "validTokens": "有效 STS"
     },
     "status": {
       "loadFailed": "部分后台统计加载失败。",
       "moduleError": "统计暂不可用"
     },
-    "modulesTitle": "后台模块",
-    "healthTitle": "领域健康度",
+    "modulesTitle": "管理工作台",
+    "healthTitle": "课程与运营健康",
     "activityTitle": "近期管理操作",
     "activityEmpty": "暂无管理操作记录",
     "cards": {
@@ -133,7 +136,7 @@
       },
       "content": {
         "title": "内容管理",
-        "description": "集中查看帖子、评论、上传文件、标签和咕咕墙活动。",
+        "description": "查看论坛帖子、评论、上传文件、标签和咕咕墙活动，保持校园讨论可读。",
         "action": "打开内容管理"
       },
       "feedback": {
@@ -147,15 +150,45 @@
         "action": "打开身份认证"
       },
       "domains": {
-        "title": "课程、数据与运维",
-        "description": "监控课程、排课、Academic Map、组队、比赛、存储、OAuth 和通知系统。",
-        "action": "打开数据与运维"
+        "title": "课程与运营健康",
+        "description": "监控课程排课、组队协作、比赛投稿和文件/通知等运营基础设施。",
+        "action": "打开健康面板"
       },
       "audit": {
         "title": "审计日志",
         "description": "追踪管理员操作的执行人、动作、目标、备注和时间。",
         "action": "打开审计日志"
       }
+    },
+    "trends": {
+      "title": "增长趋势",
+      "description": "查看最近 {days} 天校园论坛核心活动的每日新增。",
+      "daySwitcher": "趋势时间范围",
+      "days": "{days} 天",
+      "incrementLabel": "最近 {days} 天新增",
+      "emptyTitle": "暂无趋势数据",
+      "emptyDescription": "当前时间范围内还没有可展示的新增记录。",
+      "loadPartial": "趋势数据暂时不可用，其他概览仍可继续查看。",
+      "pointTitle": "{date} 的 {label}: {count}",
+      "metrics": {
+        "users": "用户",
+        "posts": "帖子",
+        "comments": "评论",
+        "files": "文件",
+        "gugu": "咕咕"
+      }
+    },
+    "healthRows": {
+      "courses": "课程与排课",
+      "courseCaption": "开课与班级数据",
+      "academicMap": "学业进度",
+      "academicCaption": "待复核课程记录",
+      "matching": "组队匹配",
+      "matchingCaption": "活跃项目",
+      "contest": "活动比赛",
+      "contestCaption": "投稿记录",
+      "operations": "系统运维",
+      "operationsCaption": "可用 STS token"
     }
   },
   "adminConsole": {
@@ -166,7 +199,8 @@
       "loadUsers": "加载用户失败。",
       "updateUser": "更新用户失败。",
       "loadContent": "加载内容失败。",
-      "updateContent": "更新内容失败。"
+      "updateContent": "更新内容失败。",
+      "loadDomains": "加载课程与运维数据失败。"
     }
   },
   "adminUsers": {
@@ -234,7 +268,7 @@
   },
   "adminContent": {
     "title": "内容管理",
-    "description": "管理论坛帖子和评论，同时监控标签、文件和咕咕墙活动。",
+    "description": "管理论坛帖子、评论、咕咕消息和上传文件，所有高风险操作都会以软删除和审计记录处理。",
     "metrics": {
       "posts": "帖子",
       "comments": "评论",
@@ -243,7 +277,9 @@
     },
     "tabs": {
       "posts": "帖子",
-      "comments": "评论"
+      "comments": "评论",
+      "gugu": "咕咕",
+      "files": "文件"
     },
     "filters": {
       "search": "搜索",
@@ -264,19 +300,31 @@
       "deletePost": "在管理后台软删除帖子",
       "restorePost": "在管理后台恢复帖子",
       "deleteComment": "在管理后台软删除评论",
-      "restoreComment": "在管理后台恢复评论"
+      "restoreComment": "在管理后台恢复评论",
+      "deleteGugu": "在管理后台软删除咕咕消息",
+      "restoreGugu": "在管理后台恢复咕咕消息",
+      "deleteFile": "在管理后台软删除文件",
+      "restoreFile": "在管理后台恢复文件"
     },
     "confirm": {
       "deletePost": "确定软删除该帖子吗？",
       "restorePost": "确定恢复该帖子吗？",
       "deleteComment": "确定软删除该评论吗？",
-      "restoreComment": "确定恢复该评论吗？"
+      "restoreComment": "确定恢复该评论吗？",
+      "deleteGugu": "确定软删除该咕咕消息吗？",
+      "restoreGugu": "确定恢复该咕咕消息吗？",
+      "deleteFile": "确定软删除该文件吗？",
+      "restoreFile": "确定恢复该文件吗？"
     },
     "messages": {
       "postDeleted": "帖子已删除。",
       "postRestored": "帖子已恢复。",
       "commentDeleted": "评论已删除。",
-      "commentRestored": "评论已恢复。"
+      "commentRestored": "评论已恢复。",
+      "guguDeleted": "咕咕消息已删除。",
+      "guguRestored": "咕咕消息已恢复。",
+      "fileDeleted": "文件已删除。",
+      "fileRestored": "文件已恢复。"
     },
     "errors": {
       "title": "加载失败"
@@ -298,11 +346,18 @@
       "comments": "{count} 条评论",
       "reactions": "{count} 个反应",
       "views": "{count} 次浏览"
+    },
+    "guguStats": {
+      "replyTo": "回复 #{id}"
+    },
+    "fileStats": {
+      "size": "{size} 字节",
+      "unknownMime": "未知类型"
     }
   },
   "adminDomains": {
-    "title": "数据与运维",
-    "description": "监控课程数据、Academic Map、组队、比赛、存储、OAuth、通知和推送基础设施。",
+    "title": "课程与运维",
+    "description": "监控课程、排课、组队、比赛、存储、OAuth、通知和推送基础设施。",
     "metrics": {
       "courses": "课程",
       "offerings": "开课",
@@ -319,16 +374,16 @@
     "sections": {
       "courses": "课程与排课",
       "academicMap": "Academic Map",
-      "matching": "组队匹配",
-      "contest": "比赛",
-      "operations": "系统运维"
+      "matching": "组队协作",
+      "contest": "校园比赛",
+      "operations": "运营基础设施"
     },
     "descriptions": {
       "courses": "课程目录、开课、班级与上课时间数据健康度。",
       "academicMap": "只展示培养方案与用户记录聚合健康度，不暴露私人绩点。",
-      "matching": "组队匹配子系统的项目和用户画像健康度。",
-      "contest": "比赛配置、组织者与投稿数量。",
-      "operations": "存储、STS、OAuth、通知和推送基础设施。"
+      "matching": "课程项目和校园协作场景里的组队资料健康度。",
+      "contest": "校园比赛配置、组织者与投稿数量。",
+      "operations": "文件存储、STS、OAuth、通知和推送基础设施。"
     },
     "labels": {
       "activeCourses": "活跃课程",

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -145,7 +145,7 @@ export default defineNuxtConfig({
     },
     // preset: "static",
     prerender: {
-      crawlLinks: true, // prevent crawler from following <a> to /users etc.
+      crawlLinks: false, // SSR deployment does not need link crawling during build.
       failOnError: false, // ignore 404 during prerender
       // routes: ["/", "/login", "/register"], // optional: define known static routes
       ignore: [

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -7,6 +7,12 @@ const appBuildVersion =
   process.env.VERCEL_GIT_COMMIT_SHA ||
   process.env.CF_PAGES_COMMIT_SHA ||
   pkg.version;
+const apiBaseUrl = (
+  process.env.NUXT_PUBLIC_API_BASE_URL ||
+  (process.env.NODE_ENV === "development"
+    ? "http://localhost:8000"
+    : "https://unikorn.axfff.com")
+).replace(/\/$/, "");
 
 export default defineNuxtConfig({
   compatibilityDate: "2025-03-24",
@@ -133,7 +139,7 @@ export default defineNuxtConfig({
     // 否则 /api/auth/login 会变成上游 /auth/login 导致 404。
     devProxy: {
       "/api": {
-        target: "https://dev.unikorn.axfff.com/api",
+        target: `${apiBaseUrl}/api`,
         changeOrigin: true,
       },
     },
@@ -168,11 +174,7 @@ export default defineNuxtConfig({
     public: {
       appVersion: pkg.version,
       appBuildVersion,
-      apiBaseUrl:
-        process.env.NUXT_PUBLIC_API_BASE_URL ||
-        (process.env.NODE_ENV === "development"
-          ? "http://localhost:3000"
-          : "https://unikorn.axfff.com"),
+      apiBaseUrl,
     },
   },
   ssr: true,

--- a/pages/admin/content.vue
+++ b/pages/admin/content.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { AdminComment, AdminContentSummary, AdminPost } from "~/types/admin";
+import type { AdminComment, AdminContentSummary, AdminFile, AdminGuguMessage, AdminPost } from "~/types/admin";
 
 definePageMeta({
   middleware: "admin",
@@ -8,12 +8,26 @@ definePageMeta({
 
 const { t } = useI18n();
 const { formatDate } = useDateFormat();
-const { getContentSummary, getPosts, getComments, setPostDeleted, setCommentDeleted } = useAdminConsole();
+const {
+  getContentSummary,
+  getPosts,
+  getComments,
+  getFiles,
+  getGuguMessages,
+  setPostDeleted,
+  setCommentDeleted,
+  setFileDeleted,
+  setGuguDeleted,
+} = useAdminConsole();
 
-const activeTab = ref<"posts" | "comments">("posts");
+type ContentTab = "posts" | "comments" | "gugu" | "files";
+
+const activeTab = ref<ContentTab>("posts");
 const summary = ref<AdminContentSummary | null>(null);
 const posts = ref<AdminPost[]>([]);
 const comments = ref<AdminComment[]>([]);
+const guguMessages = ref<AdminGuguMessage[]>([]);
+const files = ref<AdminFile[]>([]);
 const loading = ref(true);
 const error = ref("");
 const notice = ref<{ type: "success" | "error"; message: string } | null>(null);
@@ -49,17 +63,30 @@ async function loadContent() {
       page: currentPage.value,
       per_page: perPage,
     };
+    const listRequest = {
+      posts: () => getPosts(query),
+      comments: () => getComments(query),
+      gugu: () => getGuguMessages(query),
+      files: () => getFiles(query),
+    }[activeTab.value];
+
     const [summaryData, listData] = await Promise.all([
       getContentSummary(),
-      activeTab.value === "posts" ? getPosts(query) : getComments(query),
+      listRequest(),
     ]);
     summary.value = summaryData;
+    posts.value = [];
+    comments.value = [];
+    guguMessages.value = [];
+    files.value = [];
     if (activeTab.value === "posts") {
       posts.value = (listData as any).posts || [];
-      comments.value = [];
-    } else {
+    } else if (activeTab.value === "comments") {
       comments.value = (listData as any).comments || [];
-      posts.value = [];
+    } else if (activeTab.value === "gugu") {
+      guguMessages.value = (listData as any).gugu || (listData as any).messages || [];
+    } else {
+      files.value = (listData as any).files || [];
     }
     totalItems.value = listData.total;
     totalPages.value = Math.max(1, listData.pages || 1);
@@ -69,6 +96,8 @@ async function loadContent() {
     loading.value = false;
   }
 }
+
+const hasAnyRows = computed(() => posts.value.length || comments.value.length || guguMessages.value.length || files.value.length);
 
 function resetAndLoad() {
   currentPage.value = 1;
@@ -105,6 +134,36 @@ async function toggleComment(comment: AdminComment) {
   }
 }
 
+async function toggleGugu(message: AdminGuguMessage) {
+  const nextDeleted = !message.is_deleted;
+  if (!window.confirm(nextDeleted ? t("adminContent.confirm.deleteGugu") : t("adminContent.confirm.restoreGugu"))) return;
+  busyKey.value = `gugu-${message.id}`;
+  try {
+    await setGuguDeleted(message.id, nextDeleted, nextDeleted ? t("adminContent.audit.deleteGugu") : t("adminContent.audit.restoreGugu"));
+    setNotice("success", nextDeleted ? t("adminContent.messages.guguDeleted") : t("adminContent.messages.guguRestored"));
+    await loadContent();
+  } catch (err) {
+    setNotice("error", err instanceof Error ? err.message : t("adminConsole.errors.updateContent"));
+  } finally {
+    busyKey.value = "";
+  }
+}
+
+async function toggleFile(file: AdminFile) {
+  const nextDeleted = !file.is_deleted;
+  if (!window.confirm(nextDeleted ? t("adminContent.confirm.deleteFile") : t("adminContent.confirm.restoreFile"))) return;
+  busyKey.value = `file-${file.id}`;
+  try {
+    await setFileDeleted(file.id, nextDeleted, nextDeleted ? t("adminContent.audit.deleteFile") : t("adminContent.audit.restoreFile"));
+    setNotice("success", nextDeleted ? t("adminContent.messages.fileDeleted") : t("adminContent.messages.fileRestored"));
+    await loadContent();
+  } catch (err) {
+    setNotice("error", err instanceof Error ? err.message : t("adminConsole.errors.updateContent"));
+  } finally {
+    busyKey.value = "";
+  }
+}
+
 watch([activeTab, selectedDeleted], resetAndLoad);
 onMounted(loadContent);
 </script>
@@ -125,6 +184,8 @@ onMounted(loadContent);
       <div class="admin-content__tabs">
         <button type="button" :class="{ active: activeTab === 'posts' }" @click="activeTab = 'posts'">{{ t("adminContent.tabs.posts") }}</button>
         <button type="button" :class="{ active: activeTab === 'comments' }" @click="activeTab = 'comments'">{{ t("adminContent.tabs.comments") }}</button>
+        <button type="button" :class="{ active: activeTab === 'gugu' }" @click="activeTab = 'gugu'">{{ t("adminContent.tabs.gugu") }}</button>
+        <button type="button" :class="{ active: activeTab === 'files' }" @click="activeTab = 'files'">{{ t("adminContent.tabs.files") }}</button>
       </div>
       <label>
         <span>{{ t("adminContent.filters.search") }}</span>
@@ -144,7 +205,7 @@ onMounted(loadContent);
     </AdminFilterBar>
 
     <p v-if="notice" class="admin-content__notice" :class="`admin-content__notice--${notice.type}`">{{ notice.message }}</p>
-    <AdminStateBlock v-if="loading && !posts.length && !comments.length" :title="t('common.loading')" />
+    <AdminStateBlock v-if="loading && !hasAnyRows" :title="t('common.loading')" />
     <AdminStateBlock v-else-if="error" tone="error" :title="t('adminContent.errors.title')" :message="error" />
 
     <div v-else-if="activeTab === 'posts'" class="admin-content__list">
@@ -165,7 +226,7 @@ onMounted(loadContent);
       </article>
     </div>
 
-    <div v-else class="admin-content__list">
+    <div v-else-if="activeTab === 'comments'" class="admin-content__list">
       <AdminStateBlock v-if="!comments.length" :title="t('adminContent.empty.title')" :message="t('adminContent.empty.description')" />
       <article v-for="comment in comments" v-else :key="comment.id" class="admin-content__card" :class="{ 'admin-content__card--deleted': comment.is_deleted }">
         <div>
@@ -178,6 +239,41 @@ onMounted(loadContent);
         </div>
         <button type="button" :disabled="!!busyKey" @click="toggleComment(comment)">
           {{ comment.is_deleted ? t("adminContent.actions.restore") : t("adminContent.actions.delete") }}
+        </button>
+      </article>
+    </div>
+
+    <div v-else-if="activeTab === 'gugu'" class="admin-content__list">
+      <AdminStateBlock v-if="!guguMessages.length" :title="t('adminContent.empty.title')" :message="t('adminContent.empty.description')" />
+      <article v-for="message in guguMessages" v-else :key="message.id" class="admin-content__card" :class="{ 'admin-content__card--deleted': message.is_deleted }">
+        <div>
+          <strong>{{ message.content }}</strong>
+          <p>{{ message.author || t("adminConsole.unknown") }} · {{ t("adminContent.createdAt", { date: formatDate(message.created_at, { year: 'numeric', month: 'short', day: 'numeric' }) }) }}</p>
+        </div>
+        <div class="admin-content__stats">
+          <span>{{ t("adminContent.guguStats.replyTo", { id: message.reply_to_message_id || "-" }) }}</span>
+          <span v-if="message.is_deleted">{{ t("adminContent.deleted") }}</span>
+        </div>
+        <button type="button" :disabled="!!busyKey" @click="toggleGugu(message)">
+          {{ message.is_deleted ? t("adminContent.actions.restore") : t("adminContent.actions.delete") }}
+        </button>
+      </article>
+    </div>
+
+    <div v-else class="admin-content__list">
+      <AdminStateBlock v-if="!files.length" :title="t('adminContent.empty.title')" :message="t('adminContent.empty.description')" />
+      <article v-for="file in files" v-else :key="file.id" class="admin-content__card" :class="{ 'admin-content__card--deleted': file.is_deleted }">
+        <div>
+          <strong>{{ file.original_filename }}</strong>
+          <p>{{ file.owner || t("adminConsole.unknown") }} · {{ file.file_type }} · {{ file.status }}</p>
+        </div>
+        <div class="admin-content__stats">
+          <span>{{ t("adminContent.fileStats.size", { size: file.file_size ?? 0 }) }}</span>
+          <span>{{ file.mime_type || t("adminContent.fileStats.unknownMime") }}</span>
+          <span v-if="file.is_deleted">{{ t("adminContent.deleted") }}</span>
+        </div>
+        <button type="button" :disabled="!!busyKey" @click="toggleFile(file)">
+          {{ file.is_deleted ? t("adminContent.actions.restore") : t("adminContent.actions.delete") }}
         </button>
       </article>
     </div>

--- a/pages/admin/domains.vue
+++ b/pages/admin/domains.vue
@@ -1,5 +1,10 @@
 <script setup lang="ts">
-import type { AdminOverviewResponse } from "~/types/admin";
+import type {
+  AdminContestSummary,
+  AdminCoursesSummary,
+  AdminMatchingSummary,
+  AdminOperationsSummary,
+} from "~/types/admin";
 
 definePageMeta({
   middleware: "admin",
@@ -7,43 +12,38 @@ definePageMeta({
 });
 
 const { t } = useI18n();
-const { getOverview } = useAdminConsole();
+const { getCoursesSummary, getMatchingSummary, getContestSummary, getOperationsSummary } = useAdminConsole();
 
-const overview = ref<AdminOverviewResponse | null>(null);
+const coursesSummary = ref<AdminCoursesSummary | null>(null);
+const matchingSummary = ref<AdminMatchingSummary | null>(null);
+const contestSummary = ref<AdminContestSummary | null>(null);
+const operationsSummary = ref<AdminOperationsSummary | null>(null);
 const loading = ref(true);
 const error = ref("");
 
 const metricItems = computed(() => [
-  { key: "courses", label: t("adminDomains.metrics.courses"), value: overview.value?.metrics.courses.courses ?? 0 },
-  { key: "offerings", label: t("adminDomains.metrics.offerings"), value: overview.value?.metrics.courses.offerings ?? 0 },
-  { key: "projects", label: t("adminDomains.metrics.projects"), value: overview.value?.metrics.matching.projects ?? 0 },
-  { key: "submissions", label: t("adminDomains.metrics.submissions"), value: overview.value?.metrics.contest.submissions ?? 0 },
+  { key: "courses", label: t("adminDomains.metrics.courses"), value: coursesSummary.value?.courses ?? 0 },
+  { key: "offerings", label: t("adminDomains.metrics.offerings"), value: coursesSummary.value?.offerings ?? 0 },
+  { key: "projects", label: t("adminDomains.metrics.projects"), value: matchingSummary.value?.projects ?? 0 },
+  { key: "submissions", label: t("adminDomains.metrics.submissions"), value: contestSummary.value?.submissions ?? 0 },
 ]);
 
 const sections = computed(() => {
-  const metrics = overview.value?.metrics;
-  if (!metrics) return [];
+  const courses = coursesSummary.value;
+  const matching = matchingSummary.value;
+  const contest = contestSummary.value;
+  const operations = operationsSummary.value;
+  if (!courses || !matching || !contest || !operations) return [];
   return [
     {
       key: "courses",
       title: t("adminDomains.sections.courses"),
       description: t("adminDomains.descriptions.courses"),
       rows: [
-        [t("adminDomains.labels.activeCourses"), metrics.courses.active_courses],
-        [t("adminDomains.labels.offerings"), metrics.courses.offerings],
-        [t("adminDomains.labels.sections"), metrics.courses.sections],
-        [t("adminDomains.labels.meetings"), metrics.courses.meetings],
-      ],
-    },
-    {
-      key: "academic",
-      title: t("adminDomains.sections.academicMap"),
-      description: t("adminDomains.descriptions.academicMap"),
-      rows: [
-        [t("adminDomains.labels.programs"), metrics.academic_map.programs],
-        [t("adminDomains.labels.requirementGroups"), metrics.academic_map.requirement_groups],
-        [t("adminDomains.labels.academicProfiles"), metrics.academic_map.user_profiles],
-        [t("adminDomains.labels.recordsNeedingReview"), metrics.academic_map.records_needing_review],
+        [t("adminDomains.labels.activeCourses"), courses.active_courses],
+        [t("adminDomains.labels.offerings"), courses.offerings],
+        [t("adminDomains.labels.sections"), courses.sections],
+        [t("adminDomains.labels.meetings"), courses.meetings],
       ],
     },
     {
@@ -51,10 +51,10 @@ const sections = computed(() => {
       title: t("adminDomains.sections.matching"),
       description: t("adminDomains.descriptions.matching"),
       rows: [
-        [t("adminDomains.labels.projects"), metrics.matching.projects],
-        [t("adminDomains.labels.activeProjects"), metrics.matching.active_projects],
-        [t("adminDomains.labels.profiles"), metrics.matching.profiles],
-        [t("adminDomains.labels.activeProfiles"), metrics.matching.active_profiles],
+        [t("adminDomains.labels.projects"), matching.projects],
+        [t("adminDomains.labels.activeProjects"), matching.active_projects],
+        [t("adminDomains.labels.profiles"), matching.profiles],
+        [t("adminDomains.labels.activeProfiles"), matching.active_profiles],
       ],
     },
     {
@@ -62,10 +62,10 @@ const sections = computed(() => {
       title: t("adminDomains.sections.contest"),
       description: t("adminDomains.descriptions.contest"),
       rows: [
-        [t("adminDomains.labels.contests"), metrics.contest.contests],
-        [t("adminDomains.labels.activeContests"), metrics.contest.active_contests],
-        [t("adminDomains.labels.organizers"), metrics.contest.organizers],
-        [t("adminDomains.labels.submissions"), metrics.contest.submissions],
+        [t("adminDomains.labels.contests"), contest.contests],
+        [t("adminDomains.labels.activeContests"), contest.active_contests],
+        [t("adminDomains.labels.organizers"), contest.organizers],
+        [t("adminDomains.labels.submissions"), contest.submissions],
       ],
     },
     {
@@ -73,10 +73,10 @@ const sections = computed(() => {
       title: t("adminDomains.sections.operations"),
       description: t("adminDomains.descriptions.operations"),
       rows: [
-        [t("adminDomains.labels.files"), metrics.operations.files],
-        [t("adminDomains.labels.validStsTokens"), metrics.operations.valid_sts_tokens],
-        [t("adminDomains.labels.oauthClients"), metrics.operations.oauth_clients],
-        [t("adminDomains.labels.pushSubscriptions"), metrics.operations.push_subscriptions],
+        [t("adminDomains.labels.files"), operations.files],
+        [t("adminDomains.labels.validStsTokens"), operations.valid_sts_tokens],
+        [t("adminDomains.labels.oauthClients"), operations.oauth_clients],
+        [t("adminDomains.labels.pushSubscriptions"), operations.push_subscriptions],
       ],
     },
   ];
@@ -86,9 +86,18 @@ async function loadOverview() {
   loading.value = true;
   error.value = "";
   try {
-    overview.value = await getOverview();
+    const [courses, matching, contest, operations] = await Promise.all([
+      getCoursesSummary(),
+      getMatchingSummary(),
+      getContestSummary(),
+      getOperationsSummary(),
+    ]);
+    coursesSummary.value = courses;
+    matchingSummary.value = matching;
+    contestSummary.value = contest;
+    operationsSummary.value = operations;
   } catch (err) {
-    error.value = err instanceof Error ? err.message : t("adminConsole.errors.loadOverview");
+    error.value = err instanceof Error ? err.message : t("adminConsole.errors.loadDomains");
   } finally {
     loading.value = false;
   }
@@ -108,7 +117,7 @@ onMounted(loadOverview);
     </AdminPageHeader>
 
     <AdminMetricStrip :items="metricItems" />
-    <AdminStateBlock v-if="loading && !overview" :title="t('common.loading')" />
+    <AdminStateBlock v-if="loading && !coursesSummary" :title="t('common.loading')" />
     <AdminStateBlock v-else-if="error" tone="error" :title="t('adminDomains.errors.title')" :message="error" />
 
     <div v-else class="admin-domains__grid">

--- a/pages/admin/index.vue
+++ b/pages/admin/index.vue
@@ -1,9 +1,19 @@
 <script setup lang="ts">
-import type { AdminOverviewResponse } from "~/types/admin";
+import type {
+  AdminOverviewResponse,
+  AdminOverviewTrendPoint,
+  AdminOverviewTrendsPayload,
+} from "~/types/admin";
+
+type TrendMetricDefinition = {
+  key: string
+  label: string
+  paths: string[]
+};
 
 const { t } = useI18n();
 const { getLocalePath } = useAppLocale();
-const { getOverview } = useAdminConsole();
+const { getOverview, getOverviewTrends } = useAdminConsole();
 
 definePageMeta({
   middleware: "admin",
@@ -13,11 +23,43 @@ definePageMeta({
 const loading = ref(false);
 const loadError = ref<string | null>(null);
 const overview = ref<AdminOverviewResponse | null>(null);
+const selectedTrendDays = ref(7);
+const trendPoints = ref<AdminOverviewTrendPoint[]>([]);
+const trendLoadError = ref(false);
+const trendDayOptions = [7, 30];
 
-const metricValue = (value: number | null) => {
-  if (value !== null) return value;
+const metricValue = (value: number | null | undefined) => {
+  if (typeof value === "number" && Number.isFinite(value)) return value.toLocaleString();
   return loading.value ? "..." : "-";
 };
+
+const trendMetricDefinitions = computed<TrendMetricDefinition[]>(() => [
+  {
+    key: "users",
+    label: t("adminOverview.trends.metrics.users"),
+    paths: ["users", "new_users", "registrations", "users.new", "users.total"],
+  },
+  {
+    key: "posts",
+    label: t("adminOverview.trends.metrics.posts"),
+    paths: ["posts", "new_posts", "content.posts", "content.posts.total"],
+  },
+  {
+    key: "comments",
+    label: t("adminOverview.trends.metrics.comments"),
+    paths: ["comments", "new_comments", "content.comments", "content.comments.total"],
+  },
+  {
+    key: "files",
+    label: t("adminOverview.trends.metrics.files"),
+    paths: ["files", "new_files", "content.files", "content.files.total"],
+  },
+  {
+    key: "gugu",
+    label: t("adminOverview.trends.metrics.gugu"),
+    paths: ["gugu", "gugu_messages", "new_gugu", "content.gugu", "content.gugu.messages"],
+  },
+]);
 
 const metricItems = computed(() => [
   {
@@ -38,7 +80,7 @@ const metricItems = computed(() => [
   {
     key: "active-users",
     label: t("adminOverview.metrics.activeUsers"),
-    value: metricValue(overview.value?.metrics.users.active ?? null),
+    value: metricValue(overview.value?.metrics.users.active),
   },
 ]);
 
@@ -49,8 +91,8 @@ const cards = computed(() => [
     action: t("adminOverview.cards.users.action"),
     to: getLocalePath("/admin/users"),
     stats: [
-      { label: t("adminOverview.metrics.usersTotal"), value: metricValue(overview.value?.metrics.users.total ?? null) },
-      { label: t("adminOverview.metrics.adminUsers"), value: metricValue(overview.value?.metrics.users.admins ?? null) },
+      { label: t("adminOverview.metrics.usersTotal"), value: metricValue(overview.value?.metrics.users.total) },
+      { label: t("adminOverview.metrics.adminUsers"), value: metricValue(overview.value?.metrics.users.admins) },
     ],
   },
   {
@@ -59,8 +101,9 @@ const cards = computed(() => [
     action: t("adminOverview.cards.content.action"),
     to: getLocalePath("/admin/content"),
     stats: [
-      { label: t("adminOverview.metrics.postsTotal"), value: metricValue(overview.value?.metrics.content.posts.total ?? null) },
-      { label: t("adminOverview.metrics.commentsTotal"), value: metricValue(overview.value?.metrics.content.comments.total ?? null) },
+      { label: t("adminOverview.metrics.postsTotal"), value: metricValue(overview.value?.metrics.content.posts.total) },
+      { label: t("adminOverview.metrics.guguMessages"), value: metricValue(overview.value?.metrics.content.gugu.messages) },
+      { label: t("adminOverview.metrics.filesTotal"), value: metricValue(overview.value?.metrics.content.files.total) },
     ],
   },
   {
@@ -97,8 +140,9 @@ const cards = computed(() => [
     action: t("adminOverview.cards.domains.action"),
     to: getLocalePath("/admin/domains"),
     stats: [
-      { label: t("adminOverview.metrics.coursesTotal"), value: metricValue(overview.value?.metrics.courses.courses ?? null) },
-      { label: t("adminOverview.metrics.projectsTotal"), value: metricValue(overview.value?.metrics.matching.projects ?? null) },
+      { label: t("adminOverview.metrics.coursesTotal"), value: metricValue(overview.value?.metrics.courses.courses) },
+      { label: t("adminOverview.metrics.projectsTotal"), value: metricValue(overview.value?.metrics.matching.projects) },
+      { label: t("adminOverview.metrics.validTokens"), value: metricValue(overview.value?.metrics.operations.valid_sts_tokens) },
     ],
   },
   {
@@ -116,25 +160,147 @@ const healthRows = computed(() => {
   const metrics = overview.value?.metrics;
   if (!metrics) return [];
   return [
-    { key: "courses", label: t("adminDomains.sections.courses"), value: metrics.courses.offerings },
-    { key: "academic", label: t("adminDomains.sections.academicMap"), value: metrics.academic_map.user_profiles },
-    { key: "matching", label: t("adminDomains.sections.matching"), value: metrics.matching.active_projects },
-    { key: "contest", label: t("adminDomains.sections.contest"), value: metrics.contest.submissions },
-    { key: "operations", label: t("adminDomains.sections.operations"), value: metrics.operations.valid_sts_tokens },
+    {
+      key: "courses",
+      label: t("adminOverview.healthRows.courses"),
+      value: metricValue(metrics.courses.offerings),
+      caption: t("adminOverview.healthRows.courseCaption"),
+    },
+    {
+      key: "academic",
+      label: t("adminOverview.healthRows.academicMap"),
+      value: metricValue(metrics.academic_map.records_needing_review),
+      caption: t("adminOverview.healthRows.academicCaption"),
+    },
+    {
+      key: "matching",
+      label: t("adminOverview.healthRows.matching"),
+      value: metricValue(metrics.matching.active_projects),
+      caption: t("adminOverview.healthRows.matchingCaption"),
+    },
+    {
+      key: "contest",
+      label: t("adminOverview.healthRows.contest"),
+      value: metricValue(metrics.contest.submissions),
+      caption: t("adminOverview.healthRows.contestCaption"),
+    },
+    {
+      key: "operations",
+      label: t("adminOverview.healthRows.operations"),
+      value: metricValue(metrics.operations.valid_sts_tokens),
+      caption: t("adminOverview.healthRows.operationsCaption"),
+    },
   ];
 });
+
+function readNumberPath(source: unknown, path: string) {
+  let current: unknown = source;
+  for (const part of path.split(".")) {
+    if (!current || typeof current !== "object" || !(part in current)) return null;
+    current = (current as Record<string, unknown>)[part];
+  }
+
+  if (typeof current === "number" && Number.isFinite(current)) return current;
+  if (typeof current === "string" && current.trim()) {
+    const parsed = Number(current);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function getTrendValue(point: AdminOverviewTrendPoint, paths: string[]) {
+  for (const path of paths) {
+    const value = readNumberPath(point, path);
+    if (value !== null) return value;
+  }
+  return 0;
+}
+
+function normalizeTrendPayload(payload?: AdminOverviewTrendsPayload | AdminOverviewTrendPoint[] | null) {
+  if (!payload) return [];
+  const points = Array.isArray(payload) ? payload : (payload.items || payload.trends);
+  return Array.isArray(points)
+    ? points.filter((point): point is AdminOverviewTrendPoint => Boolean(point?.date))
+    : [];
+}
+
+const trendTotals = computed(() => trendMetricDefinitions.value.map((metric) => {
+  const total = trendPoints.value.reduce((sum, point) => sum + getTrendValue(point, metric.paths), 0);
+  return {
+    key: metric.key,
+    label: metric.label,
+    total,
+    value: trendPoints.value.length ? total.toLocaleString() : (loading.value ? "..." : "-"),
+  };
+}));
+
+const trendChartRows = computed(() => trendMetricDefinitions.value.map((metric) => {
+  const points = trendPoints.value.map((point) => ({
+    date: point.date,
+    value: getTrendValue(point, metric.paths),
+  }));
+  const total = points.reduce((sum, point) => sum + point.value, 0);
+  return {
+    key: metric.key,
+    label: metric.label,
+    total,
+    max: Math.max(1, ...points.map((point) => point.value)),
+    points,
+  };
+}));
+
+const hasTrendPoints = computed(() => trendPoints.value.length > 0);
+
+const trendEmptyMessage = computed(() => trendLoadError.value
+  ? t("adminOverview.trends.loadPartial")
+  : t("adminOverview.trends.emptyDescription")
+);
+
+const trendBarHeight = (value: number, max: number) => {
+  if (value <= 0) return "3px";
+  return `${Math.max(8, Math.round((value / Math.max(max, 1)) * 100))}%`;
+};
+
+const formatTrendDate = (date: string) => {
+  const parts = date.split("-");
+  return parts.length >= 3 ? `${parts[1]}/${parts[2]}` : date;
+};
 
 const loadOverview = async () => {
   loading.value = true;
   loadError.value = null;
+  trendLoadError.value = false;
 
   try {
-    overview.value = await getOverview();
+    const data = await getOverview({ days: selectedTrendDays.value });
+    overview.value = data;
+
+    const inlineTrends = normalizeTrendPayload(data.trends);
+    if (inlineTrends.length) {
+      trendPoints.value = inlineTrends;
+    } else {
+      try {
+        const trendPayload = await getOverviewTrends({ days: selectedTrendDays.value });
+        trendPoints.value = normalizeTrendPayload(trendPayload);
+        trendLoadError.value = !trendPoints.value.length;
+      } catch {
+        trendPoints.value = [];
+        trendLoadError.value = true;
+      }
+    }
   } catch {
     loadError.value = t("adminOverview.status.loadFailed");
+    trendPoints.value = [];
+    trendLoadError.value = true;
   } finally {
     loading.value = false;
   }
+};
+
+const setTrendDays = (days: number) => {
+  if (selectedTrendDays.value === days || loading.value) return;
+  selectedTrendDays.value = days;
+  loadOverview();
 };
 
 onMounted(loadOverview);
@@ -161,6 +327,62 @@ onMounted(loadOverview);
       :message="loadError"
       tone="error"
     />
+
+    <section class="admin-overview__trends" :aria-label="t('adminOverview.trends.title')">
+      <div class="admin-overview__section-head">
+        <div>
+          <h2>{{ t("adminOverview.trends.title") }}</h2>
+          <p>{{ t("adminOverview.trends.description", { days: selectedTrendDays }) }}</p>
+        </div>
+        <div class="admin-overview__day-switcher" :aria-label="t('adminOverview.trends.daySwitcher')">
+          <button
+            v-for="days in trendDayOptions"
+            :key="days"
+            type="button"
+            :class="{ 'admin-overview__day-button--active': selectedTrendDays === days }"
+            :disabled="loading"
+            @click="setTrendDays(days)"
+          >
+            {{ t("adminOverview.trends.days", { days }) }}
+          </button>
+        </div>
+      </div>
+
+      <div class="admin-overview__trend-totals">
+        <article v-for="metric in trendTotals" :key="metric.key">
+          <span>{{ metric.label }}</span>
+          <strong>{{ metric.value }}</strong>
+          <small>{{ t("adminOverview.trends.incrementLabel", { days: selectedTrendDays }) }}</small>
+        </article>
+      </div>
+
+      <AdminStateBlock
+        v-if="!hasTrendPoints"
+        :title="t('adminOverview.trends.emptyTitle')"
+        :message="trendEmptyMessage"
+      />
+
+      <div v-else class="admin-overview__trend-chart">
+        <article v-for="row in trendChartRows" :key="row.key" class="admin-overview__trend-row">
+          <div class="admin-overview__trend-row-label">
+            <span>{{ row.label }}</span>
+            <strong>{{ row.total.toLocaleString() }}</strong>
+          </div>
+          <div class="admin-overview__trend-bars">
+            <div
+              v-for="point in row.points"
+              :key="`${row.key}-${point.date}`"
+              class="admin-overview__trend-point"
+              :title="t('adminOverview.trends.pointTitle', { label: row.label, date: point.date, count: point.value })"
+            >
+              <span class="admin-overview__trend-value">{{ point.value }}</span>
+              <span class="admin-overview__trend-bar" :style="{ height: trendBarHeight(point.value, row.max) }" />
+              <span class="admin-overview__trend-date">{{ formatTrendDate(point.date) }}</span>
+            </div>
+          </div>
+        </article>
+      </div>
+    </section>
 
     <section class="admin-overview__modules" :aria-label="t('adminOverview.modulesTitle')">
       <h2>{{ t("adminOverview.modulesTitle") }}</h2>
@@ -192,6 +414,7 @@ onMounted(loadOverview);
         <article v-for="row in healthRows" :key="row.key">
           <span>{{ row.label }}</span>
           <strong>{{ row.value }}</strong>
+          <small>{{ row.caption }}</small>
         </article>
       </div>
     </section>
@@ -219,7 +442,8 @@ onMounted(loadOverview);
 }
 
 .admin-overview__refresh,
-.admin-overview__action {
+.admin-overview__action,
+.admin-overview__day-switcher button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -230,7 +454,8 @@ onMounted(loadOverview);
   text-decoration: none;
 }
 
-.admin-overview__refresh {
+.admin-overview__refresh,
+.admin-overview__day-switcher button {
   border: 0;
   background: var(--interactive-primary);
   color: #fff;
@@ -239,6 +464,18 @@ onMounted(loadOverview);
   &:disabled {
     cursor: wait;
     opacity: 0.7;
+  }
+}
+
+.admin-overview__day-switcher button {
+  border: 1px solid var(--border-primary);
+  background: var(--surface-primary);
+  color: var(--text-secondary);
+
+  &.admin-overview__day-button--active {
+    border-color: var(--interactive-primary);
+    background: var(--interactive-primary);
+    color: var(--text-inverse);
   }
 }
 
@@ -257,6 +494,151 @@ onMounted(loadOverview);
     color: var(--text-primary);
     font-size: 1.1rem;
   }
+}
+
+.admin-overview__trends {
+  display: grid;
+  gap: 1rem;
+  padding: 1.15rem;
+  border: var(--card-border);
+  border-radius: 8px;
+  background: var(--surface-primary);
+  box-shadow: var(--card-shadow);
+}
+
+.admin-overview__section-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+
+  h2 {
+    margin: 0;
+    color: var(--text-primary);
+    font-size: 1.1rem;
+  }
+
+  p {
+    margin: 0.35rem 0 0;
+    color: var(--text-secondary);
+    line-height: 1.6;
+  }
+}
+
+.admin-overview__day-switcher,
+.admin-overview__trend-totals {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
+.admin-overview__trend-totals {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+
+  article {
+    padding: 0.85rem;
+    border-radius: 8px;
+    background: var(--surface-secondary);
+  }
+
+  span,
+  small {
+    display: block;
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+    font-weight: 700;
+  }
+
+  strong {
+    display: block;
+    margin: 0.25rem 0;
+    color: var(--text-primary);
+    font-size: 1.35rem;
+    line-height: 1;
+  }
+}
+
+.admin-overview__trend-chart {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.admin-overview__trend-row {
+  display: grid;
+  grid-template-columns: 120px minmax(0, 1fr);
+  gap: 1rem;
+  align-items: stretch;
+  min-width: 0;
+}
+
+.admin-overview__trend-row-label {
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  min-width: 0;
+
+  span {
+    color: var(--text-secondary);
+    font-size: 0.84rem;
+    font-weight: 700;
+  }
+
+  strong {
+    margin-top: 0.25rem;
+    color: var(--text-primary);
+    font-size: 1.15rem;
+  }
+}
+
+.admin-overview__trend-bars {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(34px, 1fr);
+  align-items: end;
+  min-height: 120px;
+  padding: 0.75rem;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--interactive-primary) 5%, var(--surface-secondary));
+  overflow-x: auto;
+}
+
+.admin-overview__trend-point {
+  display: grid;
+  grid-template-rows: 1.2rem 1fr 1rem;
+  align-items: end;
+  justify-items: center;
+  gap: 0.35rem;
+  min-width: 34px;
+  height: 100%;
+}
+
+.admin-overview__trend-value,
+.admin-overview__trend-date {
+  color: var(--text-secondary);
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.admin-overview__trend-value {
+  opacity: 0;
+  transition: opacity var(--transition-fast);
+}
+
+.admin-overview__trend-point:hover .admin-overview__trend-value {
+  opacity: 1;
+}
+
+.admin-overview__trend-bar {
+  display: block;
+  width: 12px;
+  min-height: 3px;
+  border-radius: 999px 999px 3px 3px;
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--semantic-success) 75%, var(--interactive-primary)),
+    var(--interactive-primary)
+  );
 }
 
 .admin-overview__grid {
@@ -304,6 +686,14 @@ onMounted(loadOverview);
     margin-top: 0.35rem;
     color: var(--text-primary);
     font-size: 1.35rem;
+  }
+
+  small {
+    display: block;
+    margin-top: 0.25rem;
+    color: var(--text-secondary);
+    font-size: 0.78rem;
+    line-height: 1.4;
   }
 }
 
@@ -378,6 +768,11 @@ onMounted(loadOverview);
 }
 
 @media (max-width: 768px) {
+  .admin-overview__section-head {
+    flex-direction: column;
+  }
+
+  .admin-overview__trend-totals,
   .admin-overview__grid {
     grid-template-columns: 1fr;
   }
@@ -389,6 +784,10 @@ onMounted(loadOverview);
   .admin-overview__activity-list article {
     align-items: flex-start;
     flex-direction: column;
+  }
+
+  .admin-overview__trend-row {
+    grid-template-columns: 1fr;
   }
 }
 </style>

--- a/tests/course-universe/courseUniverse.test.ts
+++ b/tests/course-universe/courseUniverse.test.ts
@@ -189,7 +189,7 @@ describe('course universe helpers', () => {
     const canvasSource = readFileSync(
       new URL('../../components/courses/universe/CourseUniverseCanvas.vue', import.meta.url),
       'utf8',
-    )
+    ).replace(/\r\n/g, '\n')
 
     expect(canvasSource).not.toContain('<foreignObject')
     expect(canvasSource).toContain('<g\n            v-for="node in visibleNodes"')

--- a/types/admin.ts
+++ b/types/admin.ts
@@ -2,24 +2,86 @@ export interface AdminMetricGroup {
   [key: string]: number | AdminMetricGroup
 }
 
+export interface AdminMetricCounts {
+  [key: string]: number
+}
+
+export interface AdminContentSummary {
+  posts: AdminMetricCounts
+  comments: AdminMetricCounts
+  tags: AdminMetricCounts
+  files: AdminMetricCounts
+  gugu: AdminMetricCounts
+}
+
+export interface AdminCoursesSummary extends AdminMetricCounts {
+  courses: number
+  active_courses: number
+  offerings: number
+  sections: number
+  meetings: number
+}
+
+export interface AdminAcademicMapSummary extends AdminMetricCounts {
+  programs: number
+  requirement_groups: number
+  user_profiles: number
+  course_records: number
+  records_needing_review: number
+}
+
+export interface AdminMatchingSummary extends AdminMetricCounts {
+  projects: number
+  active_projects: number
+  profiles: number
+  active_profiles: number
+}
+
+export interface AdminContestSummary extends AdminMetricCounts {
+  contests: number
+  active_contests: number
+  organizers: number
+  submissions: number
+}
+
+export interface AdminOperationsSummary extends AdminMetricCounts {
+  files: number
+  sts_tokens: number
+  valid_sts_tokens: number
+  oauth_clients: number
+  oauth_tokens: number
+  notifications: number
+  unread_notifications: number
+  push_subscriptions: number
+}
+
+export interface AdminOverviewTrendPoint {
+  date: string
+  [key: string]: unknown
+}
+
+export interface AdminOverviewTrendsResponse {
+  days?: number
+  start_date?: string
+  end_date?: string
+  items?: AdminOverviewTrendPoint[]
+  trends?: AdminOverviewTrendPoint[]
+}
+
+export type AdminOverviewTrendsPayload = AdminOverviewTrendPoint[] | AdminOverviewTrendsResponse
+
 export interface AdminOverviewResponse {
   metrics: {
-    users: Record<string, number>
-    content: {
-      posts: Record<string, number>
-      comments: Record<string, number>
-      tags: Record<string, number>
-      files: Record<string, number>
-      gugu: Record<string, number>
-    }
-    feedback: Record<string, number>
-    merge_requests: Record<string, number>
-    identity: Record<string, number>
-    courses: Record<string, number>
-    academic_map: Record<string, number>
-    matching: Record<string, number>
-    contest: Record<string, number>
-    operations: Record<string, number>
+    users: AdminMetricCounts
+    content: AdminContentSummary
+    feedback: AdminMetricCounts
+    merge_requests: AdminMetricCounts
+    identity: AdminMetricCounts
+    courses: AdminCoursesSummary
+    academic_map: AdminAcademicMapSummary
+    matching: AdminMatchingSummary
+    contest: AdminContestSummary
+    operations: AdminOperationsSummary
   }
   pending: {
     feedbacks: number
@@ -27,6 +89,8 @@ export interface AdminOverviewResponse {
     identity_requests: number
   }
   recent_activity: AdminAuditLog[]
+  trend_days?: number
+  trends?: AdminOverviewTrendPoint[]
 }
 
 export interface AdminAuditLog {
@@ -103,12 +167,46 @@ export interface AdminComment {
   updated_at: string
 }
 
-export interface AdminContentSummary {
-  posts: Record<string, number>
-  comments: Record<string, number>
-  tags: Record<string, number>
-  files: Record<string, number>
-  gugu: Record<string, number>
+export interface AdminFile {
+  id: number
+  user_id: number
+  owner?: string | null
+  object_name?: string
+  original_filename: string
+  file_size?: number | null
+  mime_type?: string | null
+  status: string
+  file_type: string
+  entity_type?: string | null
+  entity_id?: number | null
+  is_deleted: boolean
+  deleted_at?: string | null
+  created_at: string
+  updated_at?: string | null
+  url?: string | null
+  view_url?: string | null
+}
+
+export interface AdminGuguMessage {
+  id: number
+  content: string
+  author_id: number
+  author?: string | null
+  author_avatar?: string | null
+  reply_to_message_id?: number | null
+  reply_to?: {
+    id: number
+    content: string
+    author_id: number
+    author?: string | null
+    author_avatar?: string | null
+    created_at?: string | null
+  } | null
+  display_identity?: unknown
+  is_deleted?: boolean
+  deleted_at?: string | null
+  created_at: string
+  updated_at?: string | null
 }
 
 export interface AdminPostsResponse extends AdminListResponse<AdminPost> {
@@ -119,11 +217,29 @@ export interface AdminCommentsResponse extends AdminListResponse<AdminComment> {
   comments: AdminComment[]
 }
 
+export interface AdminFilesResponse extends AdminListResponse<AdminFile> {
+  files: AdminFile[]
+  counts?: AdminMetricCounts
+}
+
+export interface AdminGuguMessagesResponse extends AdminListResponse<AdminGuguMessage> {
+  gugu?: AdminGuguMessage[]
+  messages?: AdminGuguMessage[]
+  counts?: AdminMetricCounts
+}
+
+export interface AdminOverviewQuery {
+  days?: number
+}
+
 export interface AdminQuery {
   search?: string
   role?: string
   deleted?: '' | 'true' | 'false'
   email_verified?: '' | 'true' | 'false'
+  status?: string
+  file_type?: string
+  entity_type?: string
   page?: number
   per_page?: number
 }


### PR DESCRIPTION
## Summary
- Reworks the admin console into campus-focused overview, content, feedback/identity, and campus operations surfaces.
- Adds trend metrics, Gugu/file moderation tabs, summary API clients, admin i18n, and expanded admin types.
- Disables SSR build link crawling so the Nuxt SSR build is stable on local Windows/Node 22 while production remains Node 20 SSR.

## Validation
- `npm run test`
- `npm run i18n:check`
- `npm run build`
- local smoke: `GET http://127.0.0.1:3004/admin` returned 200