### PR TITLE
[production] Support withdrawn academic status

### DIFF
--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -1274,7 +1274,8 @@
         "in_progress": "In progress",
         "planned": "Want to take",
         "interested": "Want to take",
-        "not_taken": "Not taken"
+        "not_taken": "Not taken",
+        "withdrawn": "Withdrawn"
       },
       "noAcademicStatus": "This course is not in your Degree Progress yet.",
       "markInterested": "Mark want to take",
@@ -1442,7 +1443,8 @@
       "in_progress": "In progress",
       "planned": "Want to take",
       "interested": "Want to take",
-      "not_interested": "Not taken"
+      "not_interested": "Not taken",
+      "withdrawn": "Withdrawn"
     },
     "privacy": {
       "title": "Grade privacy",

--- a/i18n/locales/zh.json
+++ b/i18n/locales/zh.json
@@ -1274,7 +1274,8 @@
         "in_progress": "在修",
         "planned": "想修",
         "interested": "想修",
-        "not_taken": "未修"
+        "not_taken": "未修",
+        "withdrawn": "已退课"
       },
       "noAcademicStatus": "这门课还没有加入你的学业进度。",
       "markInterested": "标记想修",
@@ -1442,7 +1443,8 @@
       "in_progress": "在修",
       "planned": "想修",
       "interested": "想修",
-      "not_interested": "未修"
+      "not_interested": "未修",
+      "withdrawn": "已退课"
     },
     "privacy": {
       "title": "成绩隐私",

--- a/tests/academic-map/manual-import.test.ts
+++ b/tests/academic-map/manual-import.test.ts
@@ -181,7 +181,7 @@ describe('academic map manual import helpers', () => {
     ])
   })
 
-  it('builds a picker draft from matched SIS rows and lets the last duplicate win', () => {
+  it('builds a picker draft from matched SIS rows and keeps the newest duplicate when statuses match', () => {
     const draft = buildAcademicMapPickerDraftFromImportRows([
       {
         course_code: 'AIAA 2205',
@@ -226,6 +226,36 @@ describe('academic map manual import helpers', () => {
         grade: 'A',
         termCode: '2440',
       },
+    })
+  })
+
+  it('keeps the strongest duplicate SIS row when a withdrawn attempt appears after a retake', () => {
+    const draft = buildAcademicMapPickerDraftFromImportRows([
+      {
+        course_code: 'AIAA2205',
+        course_title: 'Introduction to Artificial Intelligence',
+        units: 3,
+        status: 'completed',
+        grade: 'A',
+        term_label: '2024-25 Summer',
+        matched_course_code: 'AIAA2205',
+      },
+      {
+        course_code: 'AIAA 2205',
+        course_title: 'Introduction to Artificial Intelligence',
+        units: 3,
+        status: 'withdrawn',
+        grade: 'W',
+        term_label: '2024-25 Fall',
+        matched_course_code: 'AIAA2205',
+      },
+    ])
+
+    expect(draft.items).toHaveLength(1)
+    expect(draft.items[0].meta).toEqual({
+      status: 'completed',
+      grade: 'A',
+      termCode: '2440',
     })
   })
 

--- a/tests/courses/courseOverviewDetail.test.ts
+++ b/tests/courses/courseOverviewDetail.test.ts
@@ -41,6 +41,12 @@ describe('course overview detail helpers', () => {
       canToggleInterest: true,
       isInterested: true,
     })
+
+    expect(getCourseOverviewAcademicState({ course_code: 'UCUG 052S', status: 'withdrawn' })).toEqual({
+      status: 'withdrawn',
+      canToggleInterest: true,
+      isInterested: false,
+    })
   })
 
   it('enables planner cart actions only for the active scheduler semester', () => {

--- a/types/academic-map.ts
+++ b/types/academic-map.ts
@@ -4,6 +4,7 @@ export type AcademicCourseStatus =
   | 'planned'
   | 'interested'
   | 'not_interested'
+  | 'withdrawn'
 
 export interface AcademicProfile {
   id?: number

--- a/utils/academicMapManualImport.ts
+++ b/utils/academicMapManualImport.ts
@@ -235,6 +235,34 @@ const academicMapTermSortValue = (term: string) => {
   return startYear * 10 + seasonRank
 }
 
+const academicMapStatusRank = (status: AcademicCourseStatus | undefined) => {
+  const ranks: Record<AcademicCourseStatus, number> = {
+    completed: 0,
+    in_progress: 1,
+    planned: 2,
+    interested: 3,
+    withdrawn: 4,
+    not_interested: 5,
+  }
+  return status ? ranks[status] ?? 6 : 6
+}
+
+const academicMapDraftItemRank = (item: AcademicMapPickerDraftItem) => {
+  const statusRank = academicMapStatusRank(item.meta.status)
+  const termRank = Number(item.meta.termCode || -1)
+  return [statusRank, -termRank] as const
+}
+
+const shouldReplaceImportedDraftItem = (
+  candidate: AcademicMapPickerDraftItem,
+  existing: AcademicMapPickerDraftItem,
+) => {
+  const candidateRank = academicMapDraftItemRank(candidate)
+  const existingRank = academicMapDraftItemRank(existing)
+  if (candidateRank[0] !== existingRank[0]) return candidateRank[0] < existingRank[0]
+  return candidateRank[1] <= existingRank[1]
+}
+
 export const buildAcademicMapRecordGroups = (
   records: AcademicCourseRecord[],
   noTermLabel: string,
@@ -304,14 +332,18 @@ export const buildAcademicMapPickerDraftFromImportRows = (
       continue
     }
     const term = normalizeAcademicMapTerm(record.term_code || record.term_label)
-    itemsByCode.set(course.compactCode, {
+    const item = {
       course,
       meta: {
         status: record.status || 'completed',
         grade: record.grade || '',
         termCode: term?.termCode || '',
       },
-    })
+    }
+    const existing = itemsByCode.get(course.compactCode)
+    if (!existing || shouldReplaceImportedDraftItem(item, existing)) {
+      itemsByCode.set(course.compactCode, item)
+    }
   }
 
   return {

--- a/utils/courseOverviewDetail.ts
+++ b/utils/courseOverviewDetail.ts
@@ -17,7 +17,7 @@ export function getCourseOverviewAcademicState(record: Pick<AcademicCourseRecord
     : record?.status === 'not_interested'
     ? 'not_taken'
     : record?.status || 'not_taken'
-  const canToggleInterest = status === 'not_taken' || status === 'interested'
+  const canToggleInterest = status === 'not_taken' || status === 'interested' || status === 'withdrawn'
 
   return {
     status,


### PR DESCRIPTION
## Summary
- Add withdrawn to the academic map frontend status union and bilingual labels.
- Keep completed retakes ahead of withdrawn duplicate import rows in manual import drafts.
- Allow withdrawn course overview records to be re-marked as interested.

## Verification
- npm run i18n:check
- npm test -- tests/academic-map/manual-import.test.ts tests/courses/courseOverviewDetail.test.ts tests/course-universe/courseUniverse.test.ts (60 passed)
- npm run build
- Dev frontend deploy succeeded: Actions run 27495742546
- Browser smoke: https://dev.unikorn.axfff.com/courses/academic-map desktop/mobile loaded without console errors or mobile horizontal overflow
