### PR TITLE
Show Common Core progress in academic map

### DIFF
--- a/components/academic-map/RequirementMatrix.vue
+++ b/components/academic-map/RequirementMatrix.vue
@@ -81,6 +81,10 @@ const sectionLabel = (section: AcademicRequirementSection) => {
   return locale.value === 'zh' ? section.label_zh || section.label_en : section.label_en
 }
 
+const categoryLabel = (category: string) => {
+  return t(`academicMap.requirements.categories.${category}`, category)
+}
+
 const sectionKindLabel = (section: AcademicRequirementSection) => {
   return t(`academicMap.requirements.sectionKinds.${section.kind}`)
 }
@@ -163,9 +167,27 @@ const progressLabel = (progress: AcademicRequirementProgress, projected = false)
   })
 }
 
+const compactProgressLabel = (progress: AcademicRequirementProgress) => {
+  if (progress.required_credits) {
+    return `${progress.counted_credits} / ${progress.required_credits}`
+  }
+  return `${progress.counted_courses} / ${progress.required_courses || '-'}`
+}
+
+const compactProgressUnit = (progress: AcademicRequirementProgress) => {
+  return progress.required_credits
+    ? t('academicMap.requirements.creditsShort')
+    : t('academicMap.requirements.coursesShort')
+}
+
 const cellState = (cell: AcademicRequirementCell) => {
   if (cell.allocation_status === 'counted' && cell.record_status) return cell.record_status
   return cell.allocation_status
+}
+
+const areaLabel = (area?: string | null) => {
+  if (!area) return ''
+  return t(`academicMap.requirements.areas.${area}`, area)
 }
 
 const toggleRow = (row: AcademicRequirementRow) => {
@@ -224,7 +246,7 @@ watch(activeMajorCode, () => {
           @keydown.enter.prevent="toggleRow(row)"
         >
           <div class="am-row-copy">
-            <span class="am-category">{{ row.category }}</span>
+            <span class="am-category">{{ categoryLabel(row.category) }}</span>
             <h3>{{ rowTitle(row) }}</h3>
             <small>{{ progressLabel(row.current) }}</small>
             <small v-if="hasProjectedChange(row.current, row.projected)" class="am-projected-copy">
@@ -240,7 +262,7 @@ watch(activeMajorCode, () => {
                 :class="['am-section-chip', `is-${section.kind}`]"
               >
                 <strong>{{ sectionLabel(section) }}</strong>
-                <small>{{ section.current.counted_courses }} / {{ section.current.required_courses || '-' }}</small>
+                <small>{{ compactProgressLabel(section.current) }} {{ compactProgressUnit(section.current) }}</small>
               </span>
               <span
                 v-if="hiddenSectionCount(row)"
@@ -271,7 +293,8 @@ watch(activeMajorCode, () => {
 
           <div class="am-progress-group">
             <div :class="['am-progress-ring', { 'is-satisfied': row.current.satisfied }]">
-              {{ row.current.counted_courses }} / {{ row.current.required_courses || '-' }}
+              <strong>{{ compactProgressLabel(row.current) }}</strong>
+              <small>{{ compactProgressUnit(row.current) }}</small>
             </div>
             <span class="am-expand-indicator">{{ expandedRowKey === row.key ? t('academicMap.requirements.collapse') : t('academicMap.requirements.expand') }}</span>
           </div>
@@ -311,6 +334,7 @@ watch(activeMajorCode, () => {
                   <strong>{{ cellLabel(cell) }}</strong>
                   <small>{{ cellTitle(cell) }}</small>
                   <small class="am-cell-status">{{ t(`academicMap.requirements.status.${cellState(cell)}`) }}</small>
+                  <small v-if="cell.area" class="am-cell-area">{{ areaLabel(cell.area) }}</small>
                   <small v-if="cell.allocation_status === 'excluded_duplicate' && cell.counted_toward">
                     {{ t('academicMap.requirements.countedToward', { section: cell.counted_toward }) }}
                   </small>
@@ -628,6 +652,22 @@ watch(activeMajorCode, () => {
   text-align: center;
   white-space: nowrap;
 
+  strong,
+  small {
+    display: block;
+    line-height: 1.05;
+  }
+
+  strong {
+    font-size: 0.82rem;
+  }
+
+  small {
+    font-size: 0.62rem;
+    font-weight: 850;
+    margin-top: 2px;
+  }
+
   &.is-satisfied {
     background:
       radial-gradient(circle, var(--surface-primary) 58%, transparent 60%),
@@ -751,6 +791,11 @@ watch(activeMajorCode, () => {
   .am-cell-status {
     color: var(--text-secondary);
     font-weight: 750;
+  }
+
+  .am-cell-area {
+    color: var(--interactive-active);
+    font-weight: 850;
   }
 
   em {

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -1489,8 +1489,29 @@
       "projectedCourseProgress": "With plan {courses} / {requiredCourses} courses",
       "creditProgress": "Current {credits} / {requiredCredits} credits",
       "projectedCreditProgress": "With plan {credits} / {requiredCredits} credits",
+      "creditsShort": "cr",
+      "coursesShort": "courses",
       "creditToConfirm": "Credit to confirm",
       "countedToward": "Counted toward: {section}",
+      "categories": {
+        "common_core": "Common Core",
+        "fundamental": "Fundamental",
+        "major_required": "Major required",
+        "major_elective": "Major elective",
+        "major": "Major"
+      },
+      "areas": {
+        "CTDL": "CTDL",
+        "HMW": "HMW",
+        "E-Comm": "E-Comm",
+        "C-Comm": "C-Comm",
+        "A": "Arts",
+        "H": "Humanities",
+        "S": "Science",
+        "T": "Technology",
+        "SA": "Social Analysis",
+        "UxOP": "UxOP"
+      },
       "sectionKinds": {
         "required": "Required",
         "choice": "Choice",

--- a/i18n/locales/zh.json
+++ b/i18n/locales/zh.json
@@ -1489,8 +1489,29 @@
       "projectedCourseProgress": "计划后 {courses} / {requiredCourses} 门",
       "creditProgress": "当前 {credits} / {requiredCredits} 学分",
       "projectedCreditProgress": "计划后 {credits} / {requiredCredits} 学分",
+      "creditsShort": "学分",
+      "coursesShort": "门",
       "creditToConfirm": "学分待核对",
       "countedToward": "已计入：{section}",
+      "categories": {
+        "common_core": "通识",
+        "fundamental": "基础",
+        "major_required": "专业必修",
+        "major_elective": "专业选修",
+        "major": "专业"
+      },
+      "areas": {
+        "CTDL": "批判思维与数据素养",
+        "HMW": "习惯、心态与身心健康",
+        "E-Comm": "英语沟通",
+        "C-Comm": "中文沟通",
+        "A": "艺术",
+        "H": "人文",
+        "S": "科学",
+        "T": "技术",
+        "SA": "社会分析",
+        "UxOP": "体验课程"
+      },
       "sectionKinds": {
         "required": "必修",
         "choice": "选项",

--- a/types/academic-map.ts
+++ b/types/academic-map.ts
@@ -93,6 +93,8 @@ export interface AcademicRequirementCell {
   counted_toward?: string | null
   credits?: number | null
   credit_source?: 'catalog' | 'record' | null
+  area?: string | null
+  section_area?: string | null
   status?: AcademicRequirementCellStatus
   raw_status?: AcademicCourseStatus | null
   shared_majors?: string[]


### PR DESCRIPTION
## Summary\n- Localize Common Core and requirement category labels\n- Display credit-first progress for Common Core rows and sections\n- Show UCUG area labels in expanded requirement cells\n\n## Verification\n- npm run i18n:check && npm run build\n- Dev deploy verified on /courses/academic-map desktop/mobile unauthenticated shell\n- Authenticated summary backend regression verified through route-level tests